### PR TITLE
hub: require Authorization on /api, enforce owner==signer, rate-limit

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
 	golang.org/x/image v0.15.0
 	golang.org/x/sync v0.9.0
+	golang.org/x/time v0.7.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gorm.io/datatypes v1.2.5
 	gorm.io/driver/postgres v1.5.7

--- a/hub/auth.go
+++ b/hub/auth.go
@@ -1,0 +1,293 @@
+package hub
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/gin-gonic/gin"
+	"golang.org/x/time/rate"
+
+	lerror "github.com/unibaseio/da-sdk-go/lib/error"
+	"github.com/unibaseio/da-sdk-go/sdk"
+)
+
+// ----------------------------------------------------------------------------
+// Tunables (env-overridable)
+// ----------------------------------------------------------------------------
+
+const (
+	ctxAuthAddrKey = "auth_addr" // recovered ETH address (lowercased, 0x...)
+
+	// signature freshness window, both sides
+	defaultAuthDriftSec int64 = 600 // 10 min
+
+	// body size caps
+	defaultMaxJSONBytes      int64 = 4 << 20  // 4 MB for /upload (JSON message)
+	defaultMaxMultipartBytes int64 = 64 << 20 // 64 MB for /uploadData (file)
+
+	// rate limit defaults
+	defaultIPReqPerSec    = 10.0
+	defaultIPBurst        = 30
+	defaultOwnerReqPerSec = 5.0
+	defaultOwnerBurst     = 15
+)
+
+func envInt64(key string, fallback int64) int64 {
+	if v := os.Getenv(key); v != "" {
+		n, err := strconv.ParseInt(v, 10, 64)
+		if err == nil {
+			return n
+		}
+	}
+	return fallback
+}
+
+func envFloat(key string, fallback float64) float64 {
+	if v := os.Getenv(key); v != "" {
+		f, err := strconv.ParseFloat(v, 64)
+		if err == nil {
+			return f
+		}
+	}
+	return fallback
+}
+
+func envInt(key string, fallback int) int {
+	if v := os.Getenv(key); v != "" {
+		n, err := strconv.Atoi(v)
+		if err == nil {
+			return n
+		}
+	}
+	return fallback
+}
+
+// authBypassPaths are exempted from AuthMiddleware. Keep this list tiny.
+var authBypassPaths = map[string]bool{
+	"/api/info": true,
+}
+
+// ----------------------------------------------------------------------------
+// Body size limit middleware
+// ----------------------------------------------------------------------------
+
+// MaxBodySize wraps r.Body with http.MaxBytesReader using a per-route cap.
+// /uploadData (multipart) gets the larger cap, everything else gets the JSON cap.
+func MaxBodySize() gin.HandlerFunc {
+	jsonCap := envInt64("HUB_MAX_JSON_BYTES", defaultMaxJSONBytes)
+	multipartCap := envInt64("HUB_MAX_MULTIPART_BYTES", defaultMaxMultipartBytes)
+
+	return func(c *gin.Context) {
+		var capBytes int64 = jsonCap
+		if c.Request.URL.Path == "/api/uploadData" {
+			capBytes = multipartCap
+		}
+		c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, capBytes)
+		c.Next()
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Auth middleware
+// ----------------------------------------------------------------------------
+
+// AuthMiddleware parses Authorization header, verifies signature, enforces
+// freshness, and stores the recovered ETH address (lowercased) in the gin
+// context under ctxAuthAddrKey.
+//
+// Any /api/* request that isn't in authBypassPaths must carry a valid signature.
+func AuthMiddleware() gin.HandlerFunc {
+	drift := envInt64("HUB_AUTH_DRIFT_SEC", defaultAuthDriftSec)
+
+	return func(c *gin.Context) {
+		if authBypassPaths[c.Request.URL.Path] {
+			c.Next()
+			return
+		}
+
+		authStr := c.GetHeader("Authorization")
+		if authStr == "" {
+			abortWithAuthError(c, fmt.Errorf("missing Authorization header"))
+			return
+		}
+
+		au, err := sdk.DecodeAuth(authStr)
+		if err != nil {
+			abortWithAuthError(c, fmt.Errorf("decode auth: %w", err))
+			return
+		}
+
+		// freshness: |now - au.Time| <= drift
+		now := time.Now().Unix()
+		delta := now - au.Time
+		if delta < 0 {
+			delta = -delta
+		}
+		if delta > drift {
+			abortWithAuthError(c, fmt.Errorf("auth timestamp out of window (delta=%ds, max=%ds)", delta, drift))
+			return
+		}
+
+		if err := sdk.VerifyAuth(au); err != nil {
+			abortWithAuthError(c, fmt.Errorf("verify auth: %w", err))
+			return
+		}
+
+		c.Set(ctxAuthAddrKey, strings.ToLower(au.Addr.Hex()))
+		c.Next()
+	}
+}
+
+func abortWithAuthError(c *gin.Context, err error) {
+	logger.Warnf("auth reject from %s %s %s: %v", c.ClientIP(), c.Request.Method, c.Request.URL.Path, err)
+	c.AbortWithStatusJSON(http.StatusUnauthorized, lerror.ToAPIError("hub", err))
+}
+
+// ----------------------------------------------------------------------------
+// Owner ownership check (signer must own the namespace they're touching)
+// ----------------------------------------------------------------------------
+
+// CtxAuthAddr returns the lowercased 0x... address stored by AuthMiddleware,
+// or "" if auth wasn't applied (e.g. on bypass routes).
+func CtxAuthAddr(c *gin.Context) string {
+	if v, ok := c.Get(ctxAuthAddrKey); ok {
+		if s, ok2 := v.(string); ok2 {
+			return s
+		}
+	}
+	return ""
+}
+
+// RequireOwnerMatch enforces:
+//  1. owner is a valid 0x-prefixed Ethereum address
+//  2. owner (lowercased) equals the signer address recovered by AuthMiddleware
+//
+// On mismatch it writes a 401 + APIError and returns false; the caller MUST
+// return immediately when this returns false.
+func RequireOwnerMatch(c *gin.Context, owner string) bool {
+	signer := CtxAuthAddr(c)
+	if signer == "" {
+		abortWithAuthError(c, fmt.Errorf("no signer in context"))
+		return false
+	}
+
+	if owner == "" {
+		abortWithAuthError(c, fmt.Errorf("owner is required"))
+		return false
+	}
+
+	if !common.IsHexAddress(owner) {
+		abortWithAuthError(c, fmt.Errorf("owner must be a 0x-prefixed Ethereum address"))
+		return false
+	}
+
+	if !strings.EqualFold(owner, signer) {
+		abortWithAuthError(c, fmt.Errorf("owner %s does not match signer %s", owner, signer))
+		return false
+	}
+
+	return true
+}
+
+// ResolveOwnerForList is the read-side variant used by list/get endpoints.
+// Behavior:
+//   - if owner is empty, default to the signer's own address
+//   - if owner is provided, it must equal the signer (and be a valid ETH addr)
+//
+// Returns (resolvedOwner, ok). When ok is false, the response has already
+// been written and the handler must return.
+func ResolveOwnerForList(c *gin.Context, owner string) (string, bool) {
+	signer := CtxAuthAddr(c)
+	if signer == "" {
+		abortWithAuthError(c, fmt.Errorf("no signer in context"))
+		return "", false
+	}
+
+	if owner == "" {
+		return signer, true
+	}
+
+	if !common.IsHexAddress(owner) {
+		abortWithAuthError(c, fmt.Errorf("owner must be a 0x-prefixed Ethereum address"))
+		return "", false
+	}
+
+	if !strings.EqualFold(owner, signer) {
+		abortWithAuthError(c, fmt.Errorf("owner %s does not match signer %s", owner, signer))
+		return "", false
+	}
+
+	return strings.ToLower(owner), true
+}
+
+// ----------------------------------------------------------------------------
+// Rate limiting (two-tier: per-IP and per-owner)
+// ----------------------------------------------------------------------------
+
+type limiterRegistry struct {
+	mu       sync.Mutex
+	limiters map[string]*rate.Limiter
+	r        rate.Limit
+	burst    int
+}
+
+func newLimiterRegistry(rps float64, burst int) *limiterRegistry {
+	return &limiterRegistry{
+		limiters: make(map[string]*rate.Limiter),
+		r:        rate.Limit(rps),
+		burst:    burst,
+	}
+}
+
+func (lr *limiterRegistry) get(key string) *rate.Limiter {
+	lr.mu.Lock()
+	defer lr.mu.Unlock()
+	if l, ok := lr.limiters[key]; ok {
+		return l
+	}
+	l := rate.NewLimiter(lr.r, lr.burst)
+	lr.limiters[key] = l
+	return l
+}
+
+// RateLimit produces a middleware that enforces:
+//   - per-IP rate (DOS protection, applies before auth-recovered identity)
+//   - per-owner rate (applied when AuthMiddleware has set ctxAuthAddrKey)
+//
+// Returns 429 on either tier exceedance.
+func RateLimit() gin.HandlerFunc {
+	ipRPS := envFloat("HUB_RATE_IP_RPS", defaultIPReqPerSec)
+	ipBurst := envInt("HUB_RATE_IP_BURST", defaultIPBurst)
+	ownerRPS := envFloat("HUB_RATE_OWNER_RPS", defaultOwnerReqPerSec)
+	ownerBurst := envInt("HUB_RATE_OWNER_BURST", defaultOwnerBurst)
+
+	ipReg := newLimiterRegistry(ipRPS, ipBurst)
+	ownerReg := newLimiterRegistry(ownerRPS, ownerBurst)
+
+	return func(c *gin.Context) {
+		// per-IP first
+		ip := c.ClientIP()
+		if ip != "" && !ipReg.get(ip).Allow() {
+			logger.Warnf("rate limit hit (ip) from %s %s", ip, c.Request.URL.Path)
+			c.AbortWithStatusJSON(http.StatusTooManyRequests, lerror.ToAPIError("hub", fmt.Errorf("rate limit exceeded (ip)")))
+			return
+		}
+
+		// per-owner if available (set by AuthMiddleware in the chain before us)
+		if addr := CtxAuthAddr(c); addr != "" {
+			if !ownerReg.get(addr).Allow() {
+				logger.Warnf("rate limit hit (owner) from %s %s", addr, c.Request.URL.Path)
+				c.AbortWithStatusJSON(http.StatusTooManyRequests, lerror.ToAPIError("hub", fmt.Errorf("rate limit exceeded (owner)")))
+				return
+			}
+		}
+
+		c.Next()
+	}
+}

--- a/hub/conversation.go
+++ b/hub/conversation.go
@@ -37,7 +37,10 @@ func (s *Server) conversationByPost(c *gin.Context) {
 	if mn == "" {
 		mn = c.PostForm("id")
 	}
-	addr := c.PostForm("owner")
+	addr, ok := ResolveOwnerForList(c, c.PostForm("owner"))
+	if !ok {
+		return
+	}
 	bucket := c.PostForm("bucket")
 
 	offset, _ := strconv.Atoi(c.PostForm("offset"))
@@ -83,7 +86,10 @@ func (s *Server) conversationByGet(c *gin.Context) {
 	if mn == "" {
 		mn = c.Query("id")
 	}
-	addr := c.Query("owner")
+	addr, ok := ResolveOwnerForList(c, c.Query("owner"))
+	if !ok {
+		return
+	}
 	bucket := c.Query("bucket")
 	offset, _ := strconv.Atoi(c.Query("offset"))
 	length, _ := strconv.Atoi(c.Query("length"))
@@ -122,7 +128,10 @@ func (s *Server) conversationByGet(c *gin.Context) {
 //	@Failure		599		{object}	lerror.APIError
 //	@Router			/api/listConversation [get]
 func (s *Server) listConversationByGet(c *gin.Context) {
-	addr := c.Query("owner")
+	addr, ok := ResolveOwnerForList(c, c.Query("owner"))
+	if !ok {
+		return
+	}
 	bucket := c.Query("bucket")
 	offset, _ := strconv.Atoi(c.Query("offset"))
 	length, _ := strconv.Atoi(c.Query("length"))
@@ -151,7 +160,10 @@ func (s *Server) listConversationByGet(c *gin.Context) {
 //	@Failure		599		{object}	lerror.APIError
 //	@Router			/api/getConversation [get]
 func (s *Server) getConversationByGet(c *gin.Context) {
-	addr := c.Query("owner")
+	addr, ok := ResolveOwnerForList(c, c.Query("owner"))
+	if !ok {
+		return
+	}
 	bucket := c.Query("bucket")
 	mn := c.Query("name")
 	res, err := s.getConversationDisplay(addr, bucket, mn)

--- a/hub/down.go
+++ b/hub/down.go
@@ -25,7 +25,10 @@ func (s *Server) downloadByGET(c *gin.Context) {
 	if mn == "" {
 		mn = c.Query("id")
 	}
-	addr := c.Query("owner")
+	addr, ok := ResolveOwnerForList(c, c.Query("owner"))
+	if !ok {
+		return
+	}
 
 	head := fmt.Sprintf("attachment; filename=\"%s\"", mn)
 	extraHeaders := map[string]string{
@@ -48,7 +51,10 @@ func (s *Server) downloadByPOST(c *gin.Context) {
 	if mn == "" {
 		mn = c.PostForm("id")
 	}
-	addr := c.PostForm("owner")
+	addr, ok := ResolveOwnerForList(c, c.PostForm("owner"))
+	if !ok {
+		return
+	}
 
 	head := fmt.Sprintf("attachment; filename=\"%s\"", mn)
 	extraHeaders := map[string]string{

--- a/hub/list.go
+++ b/hub/list.go
@@ -39,7 +39,10 @@ func (s *Server) addList(g *gin.RouterGroup) {
 //	@Failure		599		{object}	lerror.APIError
 //	@Router			/api/getAccount [get]
 func (s *Server) getAccountByGet(c *gin.Context) {
-	owner := c.Query("owner")
+	owner, ok := ResolveOwnerForList(c, c.Query("owner"))
+	if !ok {
+		return
+	}
 	res, err := s.getAccount(owner)
 	if err != nil {
 		c.JSON(599, lerror.ToAPIError("hub", err))
@@ -118,7 +121,10 @@ func (s *Server) listAccountByPost(c *gin.Context) {
 //	@Failure		599		{object}	lerror.APIError			"Internal server error"
 //	@Router			/api/getBucket [get]
 func (s *Server) getBucketByGet(c *gin.Context) {
-	owner := c.Query("owner")
+	owner, ok := ResolveOwnerForList(c, c.Query("owner"))
+	if !ok {
+		return
+	}
 	bucket := c.Query("bucket")
 	if bucket == "" {
 		bucket = c.Query("name")
@@ -149,7 +155,10 @@ func (s *Server) getBucketByGet(c *gin.Context) {
 //	@Failure		599		{object}	lerror.APIError			"Internal server error"
 //	@Router			/api/listBucket [get]
 func (s *Server) listBucketByGet(c *gin.Context) {
-	owner := c.Query("owner")
+	owner, ok := ResolveOwnerForList(c, c.Query("owner"))
+	if !ok {
+		return
+	}
 	offset, _ := strconv.Atoi(c.Query("offset"))
 	length, _ := strconv.Atoi(c.Query("length"))
 	if length == 0 {
@@ -180,7 +189,10 @@ func (s *Server) listBucketByGet(c *gin.Context) {
 //	@Failure		599		{object}	lerror.APIError			"Internal server error"
 //	@Router			/api/listBucket [post]
 func (s *Server) listBucketByPost(c *gin.Context) {
-	owner := c.PostForm("owner")
+	owner, ok := ResolveOwnerForList(c, c.PostForm("owner"))
+	if !ok {
+		return
+	}
 	offset, _ := strconv.Atoi(c.PostForm("offset"))
 	length, _ := strconv.Atoi(c.PostForm("length"))
 	if length == 0 {
@@ -210,7 +222,10 @@ func (s *Server) listBucketByPost(c *gin.Context) {
 //	@Failure		599		{object}	lerror.APIError
 //	@Router			/api/getNeedle [get]
 func (s *Server) getNeedleByGet(c *gin.Context) {
-	owner := c.Query("owner")
+	owner, ok := ResolveOwnerForList(c, c.Query("owner"))
+	if !ok {
+		return
+	}
 	bucket := c.Query("bucket")
 	name := c.Query("name")
 	res, err := s.getNeedleDisplay(owner, bucket, name)
@@ -237,7 +252,10 @@ func (s *Server) getNeedleByGet(c *gin.Context) {
 //	@Failure		599		{object}	lerror.APIError
 //	@Router			/api/listNeedle [get]
 func (s *Server) listNeedleByGet(c *gin.Context) {
-	addr := c.Query("owner")
+	addr, ok := ResolveOwnerForList(c, c.Query("owner"))
+	if !ok {
+		return
+	}
 	bucket := c.Query("bucket")
 	offset, _ := strconv.Atoi(c.Query("offset"))
 	length, _ := strconv.Atoi(c.Query("length"))
@@ -279,7 +297,10 @@ func (s *Server) listNeedleByGet(c *gin.Context) {
 //	@Failure		599		{object}	lerror.APIError
 //	@Router			/api/listNeedle [post]
 func (s *Server) listNeedleByPost(c *gin.Context) {
-	owner := c.PostForm("owner")
+	owner, ok := ResolveOwnerForList(c, c.PostForm("owner"))
+	if !ok {
+		return
+	}
 	bucket := c.PostForm("bucket")
 	offset, _ := strconv.Atoi(c.PostForm("offset"))
 	length, _ := strconv.Atoi(c.PostForm("length"))
@@ -318,7 +339,10 @@ func (s *Server) listNeedleByPost(c *gin.Context) {
 //	@Failure		599		{object}	lerror.APIError
 //	@Router			/api/listVolume [get]
 func (s *Server) listVolumeByGet(c *gin.Context) {
-	addr := c.Query("owner")
+	addr, ok := ResolveOwnerForList(c, c.Query("owner"))
+	if !ok {
+		return
+	}
 	offset, _ := strconv.Atoi(c.Query("offset"))
 	length, _ := strconv.Atoi(c.Query("length"))
 	if length == 0 {
@@ -347,7 +371,10 @@ func (s *Server) listVolumeByGet(c *gin.Context) {
 //	@Failure		599		{object}	lerror.APIError
 //	@Router			/api/listVolume [post]
 func (s *Server) listVolumeByPost(c *gin.Context) {
-	addr := c.PostForm("owner")
+	addr, ok := ResolveOwnerForList(c, c.PostForm("owner"))
+	if !ok {
+		return
+	}
 	offset, _ := strconv.Atoi(c.PostForm("offset"))
 	length, _ := strconv.Atoi(c.PostForm("length"))
 	if length == 0 {
@@ -375,7 +402,10 @@ func (s *Server) listVolumeByPost(c *gin.Context) {
 //	@Failure		599		{object}	lerror.APIError
 //	@Router			/api/getVolume [get]
 func (s *Server) getVolumeByGet(c *gin.Context) {
-	owner := c.Query("owner")
+	owner, ok := ResolveOwnerForList(c, c.Query("owner"))
+	if !ok {
+		return
+	}
 	fid, _ := strconv.Atoi(c.Query("file"))
 	res, err := s.getVolume(owner, uint64(fid))
 	if err != nil {

--- a/hub/server.go
+++ b/hub/server.go
@@ -154,7 +154,12 @@ func (s *Server) registRoute() {
 
 	s.Router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 
+	// /api group: body-size cap → auth → per-owner+per-ip rate limit.
+	// AuthMiddleware skips /api/info (see authBypassPaths) so /info stays open.
 	r := s.Router.Group("/api")
+	r.Use(MaxBodySize())
+	r.Use(AuthMiddleware())
+	r.Use(RateLimit())
 
 	s.addInfo(r)
 	s.addDownload(r)

--- a/hub/upload.go
+++ b/hub/upload.go
@@ -28,8 +28,7 @@ func (s *Server) addUpload(g *gin.RouterGroup) {
 
 func (s *Server) uploadData(c *gin.Context) {
 	addr := c.PostForm("owner")
-	if addr == "" {
-		c.JSON(599, lerror.ToAPIError("hub", fmt.Errorf("owner is required")))
+	if !RequireOwnerMatch(c, addr) {
 		return
 	}
 	bucket := c.PostForm("bucket")
@@ -72,6 +71,10 @@ func (s *Server) upload(c *gin.Context) {
 	err := c.ShouldBindJSON(&mjson)
 	if err != nil {
 		c.JSON(599, lerror.ToAPIError("hub", err))
+		return
+	}
+
+	if !RequireOwnerMatch(c, mjson.Owner) {
 		return
 	}
 


### PR DESCRIPTION
Previously every /api/* endpoint accepted requests with no Authorization header and any string as the `owner` field. Anyone could write to or read from any namespace; the Hub would then sign and submit those entries to the DA contract, billing gas to the hub operator.

This change:

  - hub/auth.go (new): AuthMiddleware verifies the Authorization header via sdk.DecodeAuth + sdk.VerifyAuth and enforces a +/-10 min timestamp window. MaxBodySize caps JSON at 4 MiB and multipart at 64 MiB. RateLimit applies per-IP (10 rps, burst 30) and per-owner (5 rps, burst 15) token buckets via golang.org/x/time/rate. All knobs are env-overridable (HUB_AUTH_DRIFT_SEC, HUB_MAX_*_BYTES, HUB_RATE_*).

  - hub/server.go: mount MaxBodySize -> AuthMiddleware -> RateLimit on the /api group. /api/info stays in an explicit bypass list.

  - hub/upload.go, hub/down.go, hub/list.go, hub/conversation.go: write handlers call RequireOwnerMatch (owner must be a 0x ETH address == recovered signer); read handlers call ResolveOwnerForList (owner defaults to signer when empty, otherwise must == signer). Strings like "noah-2026" are now rejected with 401.

  - go.mod: promote golang.org/x/time to a direct dependency (already in go.sum).

Verified: `go build ./...` and `go vet ./hub/...` pass. Existing Go SDK clients (sdk/upload.go, sdk/common.go) already send the Authorization header, so no client-side change is required for them. The Python membase client is patched separately.