### PR TITLE
hub: add auth middleware tests + standalone hub-mock for local testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,8 @@ example/test/test
 
 app/hub/hub
 
+# stray binary from `go build ./cmd/hub-mock/...` at repo root
+/hub-mock
+cmd/hub-mock/hub-mock
+
 bin/*

--- a/cmd/hub-mock/main.go
+++ b/cmd/hub-mock/main.go
@@ -1,0 +1,89 @@
+// hub-mock is a tiny standalone server that mounts ONLY the three /api
+// middlewares (MaxBodySize, AuthMiddleware, RateLimit) plus dummy handlers,
+// so you can exercise the auth/rate/size rejection paths with curl without
+// running a real hub (no chain, no LogFS, no SQLite).
+//
+// Usage:
+//
+//	CHAIN_TYPE=bnb-testnet-dao go run ./cmd/hub-mock
+//	# default listen 127.0.0.1:8086, override with -addr
+//
+// Then curl as you wish, see auth_test.go for canned payloads.
+package main
+
+import (
+	"flag"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/unibaseio/da-sdk-go/hub"
+)
+
+func main() {
+	addr := flag.String("addr", "127.0.0.1:8086", "listen address")
+	flag.Parse()
+
+	gin.SetMode(gin.ReleaseMode)
+	r := gin.Default()
+
+	g := r.Group("/api")
+	g.Use(hub.MaxBodySize())
+	g.Use(hub.AuthMiddleware())
+	g.Use(hub.RateLimit())
+
+	// bypassed
+	g.GET("/info", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true, "endpoint": "info"})
+	})
+
+	// write-style endpoints: owner must equal signer
+	upload := func(c *gin.Context) {
+		var body struct {
+			Owner   string `json:"owner"`
+			ID      string `json:"id"`
+			Message string `json:"message"`
+		}
+		if err := c.ShouldBindJSON(&body); err != nil {
+			c.JSON(599, gin.H{"err": err.Error()})
+			return
+		}
+		if !hub.RequireOwnerMatch(c, body.Owner) {
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"ok": true, "endpoint": "upload", "owner": body.Owner, "id": body.ID})
+	}
+	g.POST("/upload", upload)
+
+	uploadData := func(c *gin.Context) {
+		owner := c.PostForm("owner")
+		if !hub.RequireOwnerMatch(c, owner) {
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"ok": true, "endpoint": "uploadData", "owner": owner})
+	}
+	g.POST("/uploadData", uploadData)
+
+	// read-style endpoints: owner defaults to signer when empty
+	download := func(c *gin.Context) {
+		o := c.PostForm("owner")
+		if o == "" {
+			o = c.Query("owner")
+		}
+		owner, ok := hub.ResolveOwnerForList(c, o)
+		if !ok {
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"ok": true, "endpoint": "download", "owner": owner})
+	}
+	g.POST("/download", download)
+	g.GET("/download", download)
+
+	r.GET("/_health", func(c *gin.Context) {
+		c.String(http.StatusOK, "ok\n")
+	})
+
+	if err := r.Run(*addr); err != nil {
+		panic(err)
+	}
+}

--- a/cmd/hub-mock/smoketest.sh
+++ b/cmd/hub-mock/smoketest.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+#
+# Smoke-test the hub /api auth + owner-match + rate-limit + size-cap
+# behaviour against a running hub-mock (or a real hub).
+#
+# Usage:
+#   1) In one terminal, start the mock:
+#        cd <repo root>
+#        CHAIN_TYPE=bnb-testnet-dao go run ./cmd/hub-mock -addr 127.0.0.1:18086
+#   2) In another terminal, run this script.
+#
+# Requirements:
+#   - python3 + the membase package at $MEMBASE_REPO (default: ../membase) so we
+#     can mint Authorization headers via build_authorization().
+#   - curl, awk
+#
+# Override the target with HUB_BASE, e.g. HUB_BASE=https://testnet.hub.membase.io
+# to test the real hub once it's deployed.
+
+set -u
+
+BASE="${HUB_BASE:-http://127.0.0.1:18086}"
+MEMBASE_REPO="${MEMBASE_REPO:-$(cd "$(dirname "$0")/../../../../../membase" 2>/dev/null && pwd)}"
+
+# canonical test key (NOT a real key). Matches:
+#   addr = 0x6370eF2f4Db3611D657b90667De398a2Cc2a370C
+SK="${MEMBASE_SECRET_KEY:-0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20}"
+SIGNER="${MEMBASE_ACCOUNT:-0x6370eF2f4Db3611D657b90667De398a2Cc2a370C}"
+
+if [[ -z "$MEMBASE_REPO" || ! -d "$MEMBASE_REPO/src/membase/storage" ]]; then
+  echo "ERROR: membase repo not found. Set MEMBASE_REPO=/path/to/membase" >&2
+  exit 2
+fi
+
+mint_header() {
+  local label="$1"
+  MEMBASE_SECRET_KEY="$SK" MEMBASE_ACCOUNT="$SIGNER" \
+  python3 -c "
+import sys
+sys.path.insert(0, '$MEMBASE_REPO/src')
+from membase.storage._auth import build_authorization
+print(build_authorization(hash_label=b'$label'))
+"
+}
+
+HDR_UP=$(mint_header upload)
+HDR_DN=$(mint_header download)
+
+div() { printf '\n── %s ──────────────────────────────────────\n' "$*"; }
+expect() { # expect <wanted_code> <actual_code> <label>
+  if [[ "$2" == "$1" ]]; then
+    printf '  ✅ %s  →  HTTP %s\n' "$3" "$2"
+  else
+    printf '  ❌ %s  →  HTTP %s (wanted %s)\n' "$3" "$2" "$1"
+    fails=$((fails + 1))
+  fi
+}
+
+fails=0
+
+div "T1  /api/info  bypass (no auth)"
+code=$(curl -s -o /tmp/r.json -w "%{http_code}" "$BASE/api/info")
+expect 200 "$code" "/api/info open"
+
+div "T2  /api/upload  no Authorization header"
+code=$(curl -s -o /tmp/r.json -w "%{http_code}" -X POST "$BASE/api/upload" \
+  -H 'Content-Type: application/json' \
+  -d '{"owner":"noah-2026","id":"hello","message":"hi"}')
+expect 401 "$code" "missing header rejected"
+
+div "T3  /api/upload  owner = 'noah-2026' (not a 0x addr)"
+code=$(curl -s -o /tmp/r.json -w "%{http_code}" -X POST "$BASE/api/upload" \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: $HDR_UP" \
+  -d '{"owner":"noah-2026","id":"hello","message":"hi"}')
+expect 401 "$code" "non-0x owner rejected"
+
+div "T4  /api/upload  owner = some other ETH addr"
+code=$(curl -s -o /tmp/r.json -w "%{http_code}" -X POST "$BASE/api/upload" \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: $HDR_UP" \
+  -d '{"owner":"0x0000000000000000000000000000000000000001","id":"x","message":"y"}')
+expect 401 "$code" "mismatched owner rejected"
+
+div "T5  /api/upload  owner == signer  (happy path)"
+code=$(curl -s -o /tmp/r.json -w "%{http_code}" -X POST "$BASE/api/upload" \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: $HDR_UP" \
+  -d "{\"owner\":\"$SIGNER\",\"id\":\"hello\",\"message\":\"hi\"}")
+expect 200 "$code" "valid upload accepted"
+
+div "T6  /api/download  no owner → defaults to signer"
+code=$(curl -s -o /tmp/r.json -w "%{http_code}" -X POST "$BASE/api/download" \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -H "Authorization: $HDR_DN" \
+  --data-urlencode 'id=hello')
+expect 200 "$code" "download owner-default"
+
+div "T7  /api/download  owner = other  → reject"
+code=$(curl -s -o /tmp/r.json -w "%{http_code}" -X POST "$BASE/api/download" \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -H "Authorization: $HDR_DN" \
+  --data-urlencode 'owner=0x000000000000000000000000000000000000dead' \
+  --data-urlencode 'id=hello')
+expect 401 "$code" "mismatched download owner rejected"
+
+div "T8  rate limit  (default per-owner burst 15, spam 25)"
+hit429=0
+for i in $(seq 1 25); do
+  c=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/upload" \
+    -H 'Content-Type: application/json' \
+    -H "Authorization: $HDR_UP" \
+    -d "{\"owner\":\"$SIGNER\",\"id\":\"x$i\",\"message\":\"y\"}")
+  if [[ "$c" == "429" ]]; then hit429=$((hit429 + 1)); fi
+done
+if [[ "$hit429" -gt 0 ]]; then
+  printf '  ✅ rate-limit triggered (%d × 429)\n' "$hit429"
+else
+  printf '  ❌ no 429 seen in 25 reqs\n'
+  fails=$((fails + 1))
+fi
+
+div "T9  body size cap (5 MiB, default cap 4 MiB)"
+python3 -c "
+import sys
+body = '{\"owner\":\"$SIGNER\",\"id\":\"x\",\"message\":\"' + ('a' * (5*1024*1024)) + '\"}'
+sys.stdout.buffer.write(body.encode())
+" > /tmp/big.json
+code=$(curl -s -o /tmp/r.json -w "%{http_code}" -X POST "$BASE/api/upload" \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: $HDR_UP" \
+  --data-binary @/tmp/big.json)
+if [[ "$code" != "200" ]]; then
+  printf '  ✅ oversized body rejected  →  HTTP %s\n' "$code"
+else
+  printf '  ❌ oversized body accepted (200)\n'
+  fails=$((fails + 1))
+fi
+rm -f /tmp/big.json /tmp/r.json
+
+echo
+if [[ "$fails" -eq 0 ]]; then
+  echo "ALL GREEN ✅"
+  exit 0
+else
+  echo "FAILED: $fails check(s)"
+  exit 1
+fi

--- a/hub/auth_test.go
+++ b/hub/auth_test.go
@@ -1,0 +1,271 @@
+package hub
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"crypto/sha256"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/gin-gonic/gin"
+)
+
+// Set CHAIN_TYPE so the indirect import of sdk (which init()s on it) doesn't
+// panic. We never touch the chain in these tests.
+func init() {
+	if os.Getenv("CHAIN_TYPE") == "" {
+		os.Setenv("CHAIN_TYPE", "bnb-testnet-dao")
+	}
+	gin.SetMode(gin.TestMode)
+}
+
+// buildHeader is the test-side mirror of sdk/lib/key.BuildAuth. It produces the
+// exact Authorization header string that AuthMiddleware expects.
+func buildHeader(t *testing.T, skHex string, label string, ts int64) string {
+	t.Helper()
+	sk, err := crypto.HexToECDSA(strings.TrimPrefix(skHex, "0x"))
+	if err != nil {
+		t.Fatalf("HexToECDSA: %v", err)
+	}
+	addr := crypto.PubkeyToAddress(sk.PublicKey)
+
+	h := sha256.New()
+	h.Write([]byte(label))
+	tsb := make([]byte, 8)
+	binary.BigEndian.PutUint64(tsb, uint64(ts))
+	h.Write(tsb)
+	digest := h.Sum(nil)
+
+	sig, err := crypto.Sign(digest, sk)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+
+	payload := map[string]any{
+		"Type": "",
+		"Addr": addr.Hex(),
+		"Time": ts,
+		"Hash": "0x" + fmt.Sprintf("%x", []byte(label)),
+		"Sign": "0x" + fmt.Sprintf("%x", sig),
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	return string(b)
+}
+
+func newTestRouter() *gin.Engine {
+	r := gin.New()
+	g := r.Group("/api")
+	g.Use(MaxBodySize())
+	g.Use(AuthMiddleware())
+	g.Use(RateLimit())
+
+	// fake info endpoint (bypassed)
+	g.GET("/info", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	// fake upload that exercises RequireOwnerMatch
+	g.POST("/upload", func(c *gin.Context) {
+		var body struct {
+			Owner   string `json:"owner"`
+			ID      string `json:"id"`
+			Message string `json:"message"`
+		}
+		if err := c.ShouldBindJSON(&body); err != nil {
+			c.JSON(599, gin.H{"err": err.Error()})
+			return
+		}
+		if !RequireOwnerMatch(c, body.Owner) {
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"ok": true, "owner": body.Owner})
+	})
+
+	// fake download that exercises ResolveOwnerForList
+	g.POST("/download", func(c *gin.Context) {
+		owner, ok := ResolveOwnerForList(c, c.PostForm("owner"))
+		if !ok {
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"ok": true, "owner": owner})
+	})
+	return r
+}
+
+const testSK = "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"
+const testAddr = "0x6370eF2f4Db3611D657b90667De398a2Cc2a370C"
+
+func TestAuthMiddleware_RejectsNoHeader(t *testing.T) {
+	r := newTestRouter()
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/upload",
+		strings.NewReader(`{"owner":"`+testAddr+`","id":"x","message":"y"}`))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "missing Authorization") {
+		t.Errorf("want 'missing Authorization' in body, got %s", w.Body.String())
+	}
+}
+
+func TestAuthMiddleware_AcceptsValidSignature(t *testing.T) {
+	r := newTestRouter()
+	hdr := buildHeader(t, testSK, "upload", time.Now().Unix())
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/upload",
+		strings.NewReader(`{"owner":"`+testAddr+`","id":"x","message":"y"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", hdr)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestAuthMiddleware_RejectsStaleTimestamp(t *testing.T) {
+	r := newTestRouter()
+	// 1 hour ago — outside the default 10 min window
+	hdr := buildHeader(t, testSK, "upload", time.Now().Add(-1*time.Hour).Unix())
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/upload",
+		strings.NewReader(`{"owner":"`+testAddr+`","id":"x","message":"y"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", hdr)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "out of window") {
+		t.Errorf("want 'out of window', got %s", w.Body.String())
+	}
+}
+
+func TestOwnerMatch_RejectsNonHexOwner(t *testing.T) {
+	r := newTestRouter()
+	hdr := buildHeader(t, testSK, "upload", time.Now().Unix())
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/upload",
+		strings.NewReader(`{"owner":"noah-2026","id":"x","message":"y"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", hdr)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "Ethereum address") {
+		t.Errorf("want 'Ethereum address' err, got %s", w.Body.String())
+	}
+}
+
+func TestOwnerMatch_RejectsOtherAddress(t *testing.T) {
+	r := newTestRouter()
+	hdr := buildHeader(t, testSK, "upload", time.Now().Unix())
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/upload",
+		strings.NewReader(`{"owner":"0x0000000000000000000000000000000000000001","id":"x","message":"y"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", hdr)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "does not match signer") {
+		t.Errorf("want 'does not match signer', got %s", w.Body.String())
+	}
+}
+
+func TestResolveOwnerForList_DefaultsToSigner(t *testing.T) {
+	r := newTestRouter()
+	hdr := buildHeader(t, testSK, "download", time.Now().Unix())
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/download",
+		strings.NewReader("")) // no owner field
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", hdr)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(strings.ToLower(w.Body.String()), strings.ToLower(testAddr)) {
+		t.Errorf("expected signer addr in response, got %s", w.Body.String())
+	}
+}
+
+func TestInfoBypass(t *testing.T) {
+	r := newTestRouter()
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/info", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200 on /api/info (bypass), got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestMaxBodySize_RejectsHugePayload(t *testing.T) {
+	t.Setenv("HUB_MAX_JSON_BYTES", "1024") // 1 KiB cap for this test
+	r := newTestRouter()
+	hdr := buildHeader(t, testSK, "upload", time.Now().Unix())
+
+	big := bytes.Repeat([]byte("a"), 8192)
+	body := `{"owner":"` + testAddr + `","id":"x","message":"` + string(big) + `"}`
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/upload", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", hdr)
+	r.ServeHTTP(w, req)
+
+	// gin's ShouldBindJSON over a truncated body returns a 599 from our handler;
+	// the important thing is it doesn't succeed as 200.
+	if w.Code == http.StatusOK {
+		t.Fatalf("expected non-200 (body too large), got 200 body=%s", w.Body.String())
+	}
+}
+
+func TestRateLimit_PerOwnerKicks(t *testing.T) {
+	t.Setenv("HUB_RATE_OWNER_RPS", "1")
+	t.Setenv("HUB_RATE_OWNER_BURST", "2")
+	t.Setenv("HUB_RATE_IP_RPS", "1000") // make IP limiter effectively no-op
+	t.Setenv("HUB_RATE_IP_BURST", "1000")
+	r := newTestRouter()
+	hdr := buildHeader(t, testSK, "upload", time.Now().Unix())
+
+	hits := 0
+	for i := 0; i < 6; i++ {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/api/upload",
+			strings.NewReader(`{"owner":"`+testAddr+`","id":"x","message":"y"}`))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", hdr)
+		r.ServeHTTP(w, req)
+		if w.Code == http.StatusTooManyRequests {
+			hits++
+		}
+	}
+	if hits == 0 {
+		t.Fatalf("expected at least one 429 in 6 rapid requests")
+	}
+}


### PR DESCRIPTION
Follow-up to the /api auth hardening. Adds ways to verify the middleware behaviour without a chain, a real hub, or disk:

  - hub/auth_test.go: httptest-based unit tests covering all rejection and happy paths (missing header, stale timestamp, non-0x owner, owner!=signer, owner default-to-signer on reads, /api/info bypass, body-size cap, per-owner rate limit). Run with: CHAIN_TYPE=bnb-testnet-dao go test ./hub/ -run TestAuth -v

  - cmd/hub-mock: a tiny standalone server that mounts only the three /api middlewares (MaxBodySize -> AuthMiddleware -> RateLimit) plus dummy handlers, so the reject/accept paths can be exercised with curl. No chain, no LogFS, no SQLite. CHAIN_TYPE=bnb-testnet-dao go run ./cmd/hub-mock -addr 127.0.0.1:18086

  - cmd/hub-mock/smoketest.sh: 9 curl scenarios end-to-end, minting Authorization headers via the membase Python client's build_authorization(). Point at the real hub with HUB_BASE once deployed; the no-auth upload should flip from 200 (vulnerable) to 401 (fixed). Verified: ALL GREEN against the mock.

  - .gitignore: ignore the stray ./hub-mock binary from `go build`.