### PR TITLE
hub: make read-only /api endpoints public again, keep writes authed

### DIFF
--- a/hub/auth.go
+++ b/hub/auth.go
@@ -149,6 +149,12 @@ func abortWithAuthError(c *gin.Context, err error) {
 	c.AbortWithStatusJSON(http.StatusUnauthorized, lerror.ToAPIError("hub", err))
 }
 
+// abortWithBadRequest is for client errors on public (unauthenticated) reads —
+// e.g. a missing or malformed owner — where a 401 would be misleading.
+func abortWithBadRequest(c *gin.Context, err error) {
+	c.AbortWithStatusJSON(http.StatusBadRequest, lerror.ToAPIError("hub", err))
+}
+
 // ----------------------------------------------------------------------------
 // Owner ownership check (signer must own the namespace they're touching)
 // ----------------------------------------------------------------------------
@@ -196,17 +202,28 @@ func RequireOwnerMatch(c *gin.Context, owner string) bool {
 }
 
 // ResolveOwnerForList is the read-side variant used by list/get endpoints.
-// Behavior:
-//   - if owner is empty, default to the signer's own address
-//   - if owner is provided, it must equal the signer (and be a valid ETH addr)
+// These run on the public (unauthenticated) /api group, so the common case
+// has no signer. Behavior:
+//   - no signer (public read): an explicit, valid owner is required — anyone
+//     may browse a given owner's listing, but there's no signer to default to.
+//   - signer present (e.g. if a route is ever moved to the authed group):
+//     empty owner defaults to the signer; an explicit owner must match it.
 //
 // Returns (resolvedOwner, ok). When ok is false, the response has already
 // been written and the handler must return.
 func ResolveOwnerForList(c *gin.Context, owner string) (string, bool) {
 	signer := CtxAuthAddr(c)
+
 	if signer == "" {
-		abortWithAuthError(c, fmt.Errorf("no signer in context"))
-		return "", false
+		if owner == "" {
+			abortWithBadRequest(c, fmt.Errorf("owner is required"))
+			return "", false
+		}
+		if !common.IsHexAddress(owner) {
+			abortWithBadRequest(c, fmt.Errorf("owner must be a 0x-prefixed Ethereum address"))
+			return "", false
+		}
+		return strings.ToLower(owner), true
 	}
 
 	if owner == "" {
@@ -214,7 +231,7 @@ func ResolveOwnerForList(c *gin.Context, owner string) (string, bool) {
 	}
 
 	if !common.IsHexAddress(owner) {
-		abortWithAuthError(c, fmt.Errorf("owner must be a 0x-prefixed Ethereum address"))
+		abortWithBadRequest(c, fmt.Errorf("owner must be a 0x-prefixed Ethereum address"))
 		return "", false
 	}
 

--- a/hub/auth_test.go
+++ b/hub/auth_test.go
@@ -214,6 +214,65 @@ func TestResolveOwnerForList_DefaultsToSigner(t *testing.T) {
 	}
 }
 
+// newPublicTestRouter mirrors the public, read-only /api group in server.go:
+// body-size cap + rate limit, but NO AuthMiddleware.
+func newPublicTestRouter() *gin.Engine {
+	r := gin.New()
+	g := r.Group("/api")
+	g.Use(MaxBodySize())
+	g.Use(RateLimit())
+
+	// fake list endpoint that exercises ResolveOwnerForList on the public path
+	g.GET("/listBucket", func(c *gin.Context) {
+		owner, ok := ResolveOwnerForList(c, c.Query("owner"))
+		if !ok {
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"ok": true, "owner": owner})
+	})
+	return r
+}
+
+const otherAddr = "0x1111111111111111111111111111111111111111"
+
+func TestPublicList_NoAuthAcceptsExplicitOwner(t *testing.T) {
+	r := newPublicTestRouter()
+	w := httptest.NewRecorder()
+	// No Authorization header, explicit owner (someone else's) — must succeed.
+	req := httptest.NewRequest("GET", "/api/listBucket?owner="+otherAddr, nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200 on public list, got %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(strings.ToLower(w.Body.String()), strings.ToLower(otherAddr)) {
+		t.Errorf("expected owner addr in response, got %s", w.Body.String())
+	}
+}
+
+func TestPublicList_NoAuthRequiresOwner(t *testing.T) {
+	r := newPublicTestRouter()
+	w := httptest.NewRecorder()
+	// No auth and no owner: there's no signer to default to → 400, not 401.
+	req := httptest.NewRequest("GET", "/api/listBucket", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400 when owner missing on public list, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestPublicList_NoAuthRejectsBadOwner(t *testing.T) {
+	r := newPublicTestRouter()
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/listBucket?owner=not-an-address", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400 on malformed owner, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
 func TestInfoBypass(t *testing.T) {
 	r := newTestRouter()
 	w := httptest.NewRecorder()

--- a/hub/server.go
+++ b/hub/server.go
@@ -154,19 +154,29 @@ func (s *Server) registRoute() {
 
 	s.Router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 
-	// /api group: body-size cap → auth → per-owner+per-ip rate limit.
-	// AuthMiddleware skips /api/info (see authBypassPaths) so /info stays open.
-	r := s.Router.Group("/api")
-	r.Use(MaxBodySize())
-	r.Use(AuthMiddleware())
-	r.Use(RateLimit())
+	// Public, read-only /api group: body-size cap + per-IP rate limit, but NO
+	// Authorization required — these endpoints are browsable like a block
+	// explorer. Stored content is client-encrypted, so listing/downloading
+	// exposes only ciphertext plus metadata.
+	pub := s.Router.Group("/api")
+	pub.Use(MaxBodySize())
+	pub.Use(RateLimit())
 
-	s.addInfo(r)
-	s.addDownload(r)
-	s.addUpload(r)
-	s.addList(r)
-	s.addConversation(r)
-	s.addStat(r)
+	s.addInfo(pub)
+	s.addDownload(pub)
+	s.addList(pub)
+	s.addConversation(pub)
+	s.addStat(pub)
+
+	// Mutating /api group: body-size cap → auth → rate limit. AuthMiddleware
+	// requires a valid signed Authorization header, and each handler further
+	// enforces owner == signer (RequireOwnerMatch).
+	authed := s.Router.Group("/api")
+	authed.Use(MaxBodySize())
+	authed.Use(AuthMiddleware())
+	authed.Use(RateLimit())
+
+	s.addUpload(authed)
 }
 
 // ListenAndServe starts the HTTP server


### PR DESCRIPTION
c31ea0d put AuthMiddleware on the whole /api group, which 401'd the read-only list/get/download/conversation/stat endpoints the public explorer relies on (it sends no Authorization header).

Split routing into two groups instead of one:
  - public (no auth): info, download, list*, get*, conversation*, stat
  - authed (AuthMiddleware + owner==signer): upload, uploadData This makes the security boundary structural rather than a path allowlist that's easy to get wrong. addUpload is the only group that calls RequireOwnerMatch; conversation's POST is read-only internally and stat is global, so neither needs auth.

ResolveOwnerForList now handles the public (no-signer) case: an explicit, valid owner is required (anyone may browse a given owner's encrypted listing); missing/malformed owner returns 400 instead of a misleading 401. The signer-present branch is preserved.