### PR TITLE
hub: make owner optional on public list/get reads (list-all)

### DIFF
--- a/hub/auth.go
+++ b/hub/auth.go
@@ -204,20 +204,27 @@ func RequireOwnerMatch(c *gin.Context, owner string) bool {
 // ResolveOwnerForList is the read-side variant used by list/get endpoints.
 // These run on the public (unauthenticated) /api group, so the common case
 // has no signer. Behavior:
-//   - no signer (public read): an explicit, valid owner is required — anyone
-//     may browse a given owner's listing, but there's no signer to default to.
+//   - no signer (public read): owner is OPTIONAL. Empty means "no filter —
+//     list everything", which the explorer's global /agents and /memory
+//     browse views rely on. A provided owner must be a valid address and
+//     simply scopes the listing to that owner.
 //   - signer present (e.g. if a route is ever moved to the authed group):
 //     empty owner defaults to the signer; an explicit owner must match it.
 //
+// Stored content is client-encrypted, so an unscoped listing exposes only
+// ciphertext plus public metadata (bucket / needle names) — the same data
+// a block explorer shows.
+//
 // Returns (resolvedOwner, ok). When ok is false, the response has already
-// been written and the handler must return.
+// been written and the handler must return. An empty resolvedOwner with
+// ok==true means "list all" — the gorm queries omit a zero-value owner from
+// the WHERE clause, so this is the correct unscoped query.
 func ResolveOwnerForList(c *gin.Context, owner string) (string, bool) {
 	signer := CtxAuthAddr(c)
 
 	if signer == "" {
 		if owner == "" {
-			abortWithBadRequest(c, fmt.Errorf("owner is required"))
-			return "", false
+			return "", true
 		}
 		if !common.IsHexAddress(owner) {
 			abortWithBadRequest(c, fmt.Errorf("owner must be a 0x-prefixed Ethereum address"))

--- a/hub/auth_test.go
+++ b/hub/auth_test.go
@@ -250,15 +250,21 @@ func TestPublicList_NoAuthAcceptsExplicitOwner(t *testing.T) {
 	}
 }
 
-func TestPublicList_NoAuthRequiresOwner(t *testing.T) {
+func TestPublicList_NoAuthNoOwnerListsAll(t *testing.T) {
 	r := newPublicTestRouter()
 	w := httptest.NewRecorder()
-	// No auth and no owner: there's no signer to default to → 400, not 401.
+	// No auth and no owner: owner is optional on public reads — this is the
+	// explorer's global browse view, which lists every owner's entries.
+	// Resolves to "" (no filter → list all), so the handler runs and 200s.
 	req := httptest.NewRequest("GET", "/api/listBucket", nil)
 	r.ServeHTTP(w, req)
 
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("want 400 when owner missing on public list, got %d body=%s", w.Code, w.Body.String())
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200 (list-all) when owner omitted on public list, got %d body=%s", w.Code, w.Body.String())
+	}
+	// resolved owner is empty in the response — the unscoped query marker.
+	if !strings.Contains(w.Body.String(), `"owner":""`) {
+		t.Errorf("expected empty resolved owner (list-all) in response, got %s", w.Body.String())
 	}
 }
 


### PR DESCRIPTION
PR #4 made the read-only /api endpoints public but ResolveOwnerForList still required an explicit owner on the no-signer path, so the explorer's global browse views (/agents, /memory) — which call listBucket/listNeedle with no owner — got `{"Type":"hub","Message":"owner is required"}`.

Restore the original, documented behavior: on public reads owner is OPTIONAL. Empty owner now resolves to "" (no filter → list all); a provided owner must still be a valid address and scopes the listing. The gorm queries omit a zero-value owner from the WHERE clause, so "" is the correct unscoped query. Listings expose only ciphertext + public metadata (bucket / needle names), same as a block explorer.

The authed branch (empty owner → signer; explicit owner must match) is unchanged, so writes stay locked to owner == signer.

Test: TestPublicList_NoAuthRequiresOwner flipped to TestPublicList_NoAuthNoOwnerListsAll (200 + empty resolved owner). go build/vet + hub auth tests green.