### PR TITLE
hub(compose): set HUB_AUTH_DRIFT_SEC=7d for cached-token clients

### DIFF
--- a/docker-compose/docker-compose-hub.yml
+++ b/docker-compose/docker-compose-hub.yml
@@ -10,6 +10,17 @@ services:
     environment:
       EXPOSE_URL: ""
       MAX_SIZE: "4MB"
+      # Authorization freshness window for /api writes (seconds). Browser
+      # clients sign one token at login and cache it, so the window must be
+      # long enough to cover a session — 7 days here (client refreshes at 6d).
+      HUB_AUTH_DRIFT_SEC: "604800"
+      # Other auth tunables (uncomment to override the in-code defaults):
+      # HUB_MAX_JSON_BYTES: "4194304"        # /api/upload JSON body cap (4 MiB)
+      # HUB_MAX_MULTIPART_BYTES: "67108864"  # /api/uploadData file cap (64 MiB)
+      # HUB_RATE_IP_RPS: "10"                # per-IP rate, requests/sec
+      # HUB_RATE_IP_BURST: "30"
+      # HUB_RATE_OWNER_RPS: "5"              # per-owner rate, requests/sec
+      # HUB_RATE_OWNER_BURST: "15"
 networks:
   default:
     driver: bridge


### PR DESCRIPTION
Browser clients (the extension) sign one Authorization token at login and cache it; the default 600s window would 401 them within 10 minutes. Set the deploy window to 7 days to match the client's 6-day refresh TTL, and document the other auth tunables as commented examples.