### PR TITLE
hub: remove application-level rate limiting (broken behind reverse pr…

### DIFF
--- a/cmd/hub-mock/main.go
+++ b/cmd/hub-mock/main.go
@@ -1,7 +1,7 @@
-// hub-mock is a tiny standalone server that mounts ONLY the three /api
-// middlewares (MaxBodySize, AuthMiddleware, RateLimit) plus dummy handlers,
-// so you can exercise the auth/rate/size rejection paths with curl without
-// running a real hub (no chain, no LogFS, no SQLite).
+// hub-mock is a tiny standalone server that mounts ONLY the /api middlewares
+// (MaxBodySize, AuthMiddleware) plus dummy handlers, so you can exercise the
+// auth/size rejection paths with curl without running a real hub (no chain,
+// no LogFS, no SQLite).
 //
 // Usage:
 //
@@ -30,7 +30,6 @@ func main() {
 	g := r.Group("/api")
 	g.Use(hub.MaxBodySize())
 	g.Use(hub.AuthMiddleware())
-	g.Use(hub.RateLimit())
 
 	// bypassed
 	g.GET("/info", func(c *gin.Context) {

--- a/cmd/hub-mock/smoketest.sh
+++ b/cmd/hub-mock/smoketest.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Smoke-test the hub /api auth + owner-match + rate-limit + size-cap
+# Smoke-test the hub /api auth + owner-match + size-cap
 # behaviour against a running hub-mock (or a real hub).
 #
 # Usage:
@@ -104,23 +104,7 @@ code=$(curl -s -o /tmp/r.json -w "%{http_code}" -X POST "$BASE/api/download" \
   --data-urlencode 'id=hello')
 expect 401 "$code" "mismatched download owner rejected"
 
-div "T8  rate limit  (default per-owner burst 15, spam 25)"
-hit429=0
-for i in $(seq 1 25); do
-  c=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/api/upload" \
-    -H 'Content-Type: application/json' \
-    -H "Authorization: $HDR_UP" \
-    -d "{\"owner\":\"$SIGNER\",\"id\":\"x$i\",\"message\":\"y\"}")
-  if [[ "$c" == "429" ]]; then hit429=$((hit429 + 1)); fi
-done
-if [[ "$hit429" -gt 0 ]]; then
-  printf '  ✅ rate-limit triggered (%d × 429)\n' "$hit429"
-else
-  printf '  ❌ no 429 seen in 25 reqs\n'
-  fails=$((fails + 1))
-fi
-
-div "T9  body size cap (5 MiB, default cap 4 MiB)"
+div "T8  body size cap (5 MiB, default cap 4 MiB)"
 python3 -c "
 import sys
 body = '{\"owner\":\"$SIGNER\",\"id\":\"x\",\"message\":\"' + ('a' * (5*1024*1024)) + '\"}'

--- a/docker-compose/docker-compose-hub.yml
+++ b/docker-compose/docker-compose-hub.yml
@@ -14,13 +14,14 @@ services:
       # clients sign one token at login and cache it, so the window must be
       # long enough to cover a session — 7 days here (client refreshes at 6d).
       HUB_AUTH_DRIFT_SEC: "604800"
-      # Other auth tunables (uncomment to override the in-code defaults):
+      # Other tunables (uncomment to override the in-code defaults):
       # HUB_MAX_JSON_BYTES: "4194304"        # /api/upload JSON body cap (4 MiB)
       # HUB_MAX_MULTIPART_BYTES: "67108864"  # /api/uploadData file cap (64 MiB)
-      # HUB_RATE_IP_RPS: "10"                # per-IP rate, requests/sec
-      # HUB_RATE_IP_BURST: "30"
-      # HUB_RATE_OWNER_RPS: "5"              # per-owner rate, requests/sec
-      # HUB_RATE_OWNER_BURST: "15"
+      #
+      # NOTE: the hub does NOT do application-level rate limiting. It sits
+      # behind the explorer's reverse proxy, where every request shares the
+      # proxy's IP, so a per-IP limiter would 429 all legitimate traffic.
+      # Rate-limit at the proxy (real client IP) instead.
 networks:
   default:
     driver: bridge

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,6 @@ require (
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
 	golang.org/x/image v0.15.0
 	golang.org/x/sync v0.9.0
-	golang.org/x/time v0.7.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gorm.io/datatypes v1.2.5
 	gorm.io/driver/postgres v1.5.7

--- a/hub/auth.go
+++ b/hub/auth.go
@@ -6,12 +6,10 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gin-gonic/gin"
-	"golang.org/x/time/rate"
 
 	lerror "github.com/unibaseio/da-sdk-go/lib/error"
 	"github.com/unibaseio/da-sdk-go/sdk"
@@ -30,37 +28,11 @@ const (
 	// body size caps
 	defaultMaxJSONBytes      int64 = 4 << 20  // 4 MB for /upload (JSON message)
 	defaultMaxMultipartBytes int64 = 64 << 20 // 64 MB for /uploadData (file)
-
-	// rate limit defaults
-	defaultIPReqPerSec    = 10.0
-	defaultIPBurst        = 30
-	defaultOwnerReqPerSec = 5.0
-	defaultOwnerBurst     = 15
 )
 
 func envInt64(key string, fallback int64) int64 {
 	if v := os.Getenv(key); v != "" {
 		n, err := strconv.ParseInt(v, 10, 64)
-		if err == nil {
-			return n
-		}
-	}
-	return fallback
-}
-
-func envFloat(key string, fallback float64) float64 {
-	if v := os.Getenv(key); v != "" {
-		f, err := strconv.ParseFloat(v, 64)
-		if err == nil {
-			return f
-		}
-	}
-	return fallback
-}
-
-func envInt(key string, fallback int) int {
-	if v := os.Getenv(key); v != "" {
-		n, err := strconv.Atoi(v)
 		if err == nil {
 			return n
 		}
@@ -248,70 +220,4 @@ func ResolveOwnerForList(c *gin.Context, owner string) (string, bool) {
 	}
 
 	return strings.ToLower(owner), true
-}
-
-// ----------------------------------------------------------------------------
-// Rate limiting (two-tier: per-IP and per-owner)
-// ----------------------------------------------------------------------------
-
-type limiterRegistry struct {
-	mu       sync.Mutex
-	limiters map[string]*rate.Limiter
-	r        rate.Limit
-	burst    int
-}
-
-func newLimiterRegistry(rps float64, burst int) *limiterRegistry {
-	return &limiterRegistry{
-		limiters: make(map[string]*rate.Limiter),
-		r:        rate.Limit(rps),
-		burst:    burst,
-	}
-}
-
-func (lr *limiterRegistry) get(key string) *rate.Limiter {
-	lr.mu.Lock()
-	defer lr.mu.Unlock()
-	if l, ok := lr.limiters[key]; ok {
-		return l
-	}
-	l := rate.NewLimiter(lr.r, lr.burst)
-	lr.limiters[key] = l
-	return l
-}
-
-// RateLimit produces a middleware that enforces:
-//   - per-IP rate (DOS protection, applies before auth-recovered identity)
-//   - per-owner rate (applied when AuthMiddleware has set ctxAuthAddrKey)
-//
-// Returns 429 on either tier exceedance.
-func RateLimit() gin.HandlerFunc {
-	ipRPS := envFloat("HUB_RATE_IP_RPS", defaultIPReqPerSec)
-	ipBurst := envInt("HUB_RATE_IP_BURST", defaultIPBurst)
-	ownerRPS := envFloat("HUB_RATE_OWNER_RPS", defaultOwnerReqPerSec)
-	ownerBurst := envInt("HUB_RATE_OWNER_BURST", defaultOwnerBurst)
-
-	ipReg := newLimiterRegistry(ipRPS, ipBurst)
-	ownerReg := newLimiterRegistry(ownerRPS, ownerBurst)
-
-	return func(c *gin.Context) {
-		// per-IP first
-		ip := c.ClientIP()
-		if ip != "" && !ipReg.get(ip).Allow() {
-			logger.Warnf("rate limit hit (ip) from %s %s", ip, c.Request.URL.Path)
-			c.AbortWithStatusJSON(http.StatusTooManyRequests, lerror.ToAPIError("hub", fmt.Errorf("rate limit exceeded (ip)")))
-			return
-		}
-
-		// per-owner if available (set by AuthMiddleware in the chain before us)
-		if addr := CtxAuthAddr(c); addr != "" {
-			if !ownerReg.get(addr).Allow() {
-				logger.Warnf("rate limit hit (owner) from %s %s", addr, c.Request.URL.Path)
-				c.AbortWithStatusJSON(http.StatusTooManyRequests, lerror.ToAPIError("hub", fmt.Errorf("rate limit exceeded (owner)")))
-				return
-			}
-		}
-
-		c.Next()
-	}
 }

--- a/hub/auth_test.go
+++ b/hub/auth_test.go
@@ -68,7 +68,6 @@ func newTestRouter() *gin.Engine {
 	g := r.Group("/api")
 	g.Use(MaxBodySize())
 	g.Use(AuthMiddleware())
-	g.Use(RateLimit())
 
 	// fake info endpoint (bypassed)
 	g.GET("/info", func(c *gin.Context) {
@@ -215,12 +214,11 @@ func TestResolveOwnerForList_DefaultsToSigner(t *testing.T) {
 }
 
 // newPublicTestRouter mirrors the public, read-only /api group in server.go:
-// body-size cap + rate limit, but NO AuthMiddleware.
+// body-size cap only, NO AuthMiddleware (and no rate limiting).
 func newPublicTestRouter() *gin.Engine {
 	r := gin.New()
 	g := r.Group("/api")
 	g.Use(MaxBodySize())
-	g.Use(RateLimit())
 
 	// fake list endpoint that exercises ResolveOwnerForList on the public path
 	g.GET("/listBucket", func(c *gin.Context) {
@@ -307,30 +305,5 @@ func TestMaxBodySize_RejectsHugePayload(t *testing.T) {
 	// the important thing is it doesn't succeed as 200.
 	if w.Code == http.StatusOK {
 		t.Fatalf("expected non-200 (body too large), got 200 body=%s", w.Body.String())
-	}
-}
-
-func TestRateLimit_PerOwnerKicks(t *testing.T) {
-	t.Setenv("HUB_RATE_OWNER_RPS", "1")
-	t.Setenv("HUB_RATE_OWNER_BURST", "2")
-	t.Setenv("HUB_RATE_IP_RPS", "1000") // make IP limiter effectively no-op
-	t.Setenv("HUB_RATE_IP_BURST", "1000")
-	r := newTestRouter()
-	hdr := buildHeader(t, testSK, "upload", time.Now().Unix())
-
-	hits := 0
-	for i := 0; i < 6; i++ {
-		w := httptest.NewRecorder()
-		req := httptest.NewRequest("POST", "/api/upload",
-			strings.NewReader(`{"owner":"`+testAddr+`","id":"x","message":"y"}`))
-		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Authorization", hdr)
-		r.ServeHTTP(w, req)
-		if w.Code == http.StatusTooManyRequests {
-			hits++
-		}
-	}
-	if hits == 0 {
-		t.Fatalf("expected at least one 429 in 6 rapid requests")
 	}
 }

--- a/hub/server.go
+++ b/hub/server.go
@@ -154,13 +154,18 @@ func (s *Server) registRoute() {
 
 	s.Router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 
-	// Public, read-only /api group: body-size cap + per-IP rate limit, but NO
-	// Authorization required — these endpoints are browsable like a block
-	// explorer. Stored content is client-encrypted, so listing/downloading
-	// exposes only ciphertext plus metadata.
+	// Public, read-only /api group: body-size cap, but NO Authorization
+	// required — these endpoints are browsable like a block explorer. Stored
+	// content is client-encrypted, so listing/downloading exposes only
+	// ciphertext plus metadata.
+	//
+	// No application-level rate limiting: the hub sits behind a reverse proxy
+	// (explorer api_hub), so every request arrives from the proxy's single IP
+	// and a per-IP limiter collapses into a global one that 429s legitimate
+	// traffic. Rate limiting, if needed, belongs at the proxy where the real
+	// client IP is visible.
 	pub := s.Router.Group("/api")
 	pub.Use(MaxBodySize())
-	pub.Use(RateLimit())
 
 	s.addInfo(pub)
 	s.addDownload(pub)
@@ -168,13 +173,12 @@ func (s *Server) registRoute() {
 	s.addConversation(pub)
 	s.addStat(pub)
 
-	// Mutating /api group: body-size cap → auth → rate limit. AuthMiddleware
-	// requires a valid signed Authorization header, and each handler further
-	// enforces owner == signer (RequireOwnerMatch).
+	// Mutating /api group: body-size cap → auth. AuthMiddleware requires a
+	// valid signed Authorization header, and each handler further enforces
+	// owner == signer (RequireOwnerMatch).
 	authed := s.Router.Group("/api")
 	authed.Use(MaxBodySize())
 	authed.Use(AuthMiddleware())
-	authed.Use(RateLimit())
 
 	s.addUpload(authed)
 }


### PR DESCRIPTION
…oxy)

The hub runs behind the explorer's reverse proxy (api_hub), so every request reaches it from the proxy's single IP. The per-IP token bucket added earlier therefore collapsed into one global bucket: a single busy client (e.g. a python-requests sync agent) exhausted burst=30 and the hub 429'd all /api/download traffic for everyone — observed live as "rate limit hit (ip) from <proxy-ip>" flooding the logs while legitimate reads failed.

Per-IP rate limiting only works where the real client IP is visible. That's the proxy's job, not the hub's. Remove it entirely:

  - hub/auth.go: drop RateLimit, limiterRegistry, the rate constants and the envFloat/envInt helpers; drop the sync and golang.org/x/time/rate imports.
  - hub/server.go: stop mounting RateLimit on both /api groups; MaxBodySize (+ AuthMiddleware on writes) remain.
  - go.mod: golang.org/x/time drops to indirect via `go mod tidy`.
  - hub/auth_test.go, cmd/hub-mock: drop the rate-limit test/wiring.
  - docker-compose-hub.yml: set HUB_AUTH_DRIFT_SEC=604800 (7d, matches the extension's cached-token model) and document that rate limiting belongs at the proxy.

go build/vet + hub tests green.