### PR TITLE
Fix

### DIFF
--- a/hub/down.go
+++ b/hub/down.go
@@ -76,6 +76,13 @@ func (s *Server) download(ctx context.Context, name, owner string, w io.Writer) 
 		return size, nil
 	}
 
+	// Local miss. If this key was very recently confirmed absent, skip the
+	// expensive remote fallback chain below — this absorbs download floods for
+	// keys that don't exist (each full miss otherwise costs remote round-trips).
+	if s.missCache.has(owner, name) {
+		return 0, fmt.Errorf("no such file: %s at %s", name, owner)
+	}
+
 	fr, err := sdk.GetFileReceipt(build.ServerURL, s.auth, name)
 	if err == nil {
 		err = sdk.Download(build.ServerURL, s.auth, name, s.ps, w)
@@ -102,5 +109,7 @@ func (s *Server) download(ctx context.Context, name, owner string, w io.Writer) 
 		return res.Size, nil
 	}
 
+	// Fully missing everywhere — remember so repeat requests stay cheap.
+	s.missCache.add(owner, name)
 	return 0, fmt.Errorf("no such file: %s at %s", name, owner)
 }

--- a/hub/misscache.go
+++ b/hub/misscache.go
@@ -1,0 +1,95 @@
+package hub
+
+import (
+	"sync"
+	"time"
+)
+
+// missCache is a small TTL set of "this download key is definitely not here"
+// markers. It absorbs download floods: a client hammering /api/download for a
+// key that isn't stored would otherwise trigger the full fallback chain —
+// including remote round-trips to the gateway — on every single request
+// (~30-50ms each), which can saturate the hub. Once a key is confirmed
+// missing, subsequent lookups short-circuit to a cheap 404 until the TTL
+// expires or the key is actually written.
+//
+// Only the EXPENSIVE remote fallback is skipped; the cheap local LogFS lookup
+// still runs first on every request, so a key that gets written stays
+// immediately readable (and logFSWrite proactively evicts it anyway).
+type missCache struct {
+	mu      sync.Mutex
+	entries map[string]int64 // key -> expiry (unix nanos)
+	ttl     time.Duration
+	max     int
+}
+
+const (
+	defaultMissTTLSec   int64 = 30
+	defaultMissMaxItems       = 50000
+)
+
+func newMissCache() *missCache {
+	return &missCache{
+		entries: make(map[string]int64),
+		ttl:     time.Duration(envInt64("HUB_DOWNLOAD_MISS_TTL_SEC", defaultMissTTLSec)) * time.Second,
+		max:     defaultMissMaxItems,
+	}
+}
+
+func missKey(owner, name string) string { return owner + "/" + name }
+
+// has reports whether (owner,name) was recently confirmed missing.
+func (m *missCache) has(owner, name string) bool {
+	if m == nil || m.ttl <= 0 {
+		return false
+	}
+	k := missKey(owner, name)
+	now := time.Now().UnixNano()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	exp, ok := m.entries[k]
+	if !ok {
+		return false
+	}
+	if now >= exp {
+		delete(m.entries, k)
+		return false
+	}
+	return true
+}
+
+// add records (owner,name) as missing for one TTL window.
+func (m *missCache) add(owner, name string) {
+	if m == nil || m.ttl <= 0 {
+		return
+	}
+	k := missKey(owner, name)
+	now := time.Now().UnixNano()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.entries) >= m.max {
+		// bounded: drop expired entries; if still full, reset (a flood hits the
+		// same few keys, so the cache re-populates cheaply).
+		for ek, ee := range m.entries {
+			if now >= ee {
+				delete(m.entries, ek)
+			}
+		}
+		if len(m.entries) >= m.max {
+			m.entries = make(map[string]int64)
+		}
+	}
+	m.entries[k] = now + int64(m.ttl)
+}
+
+// del removes any miss marker for (owner,name) — call after a successful write
+// so a freshly stored key is never shadowed by a stale negative.
+func (m *missCache) del(owner, name string) {
+	if m == nil {
+		return
+	}
+	k := missKey(owner, name)
+	m.mu.Lock()
+	delete(m.entries, k)
+	m.mu.Unlock()
+}

--- a/hub/misscache_test.go
+++ b/hub/misscache_test.go
@@ -1,0 +1,66 @@
+package hub
+
+import "testing"
+
+func TestMissCache_AddHasDel(t *testing.T) {
+	m := newMissCache()
+	o, n := "0xabc", "key-1"
+
+	if m.has(o, n) {
+		t.Fatal("fresh cache should not contain key")
+	}
+	m.add(o, n)
+	if !m.has(o, n) {
+		t.Fatal("key should be present after add")
+	}
+	// different key must not collide
+	if m.has(o, "key-2") {
+		t.Fatal("unrelated key should be absent")
+	}
+	// owner scoping: same name, different owner is a different entry
+	if m.has("0xdef", n) {
+		t.Fatal("same name under a different owner should be absent")
+	}
+
+	m.del(o, n)
+	if m.has(o, n) {
+		t.Fatal("key should be gone after del")
+	}
+}
+
+func TestMissCache_ExpiredEntryEvicted(t *testing.T) {
+	m := newMissCache()
+	o, n := "0xabc", "key-1"
+	m.add(o, n)
+	// force expiry into the past
+	m.mu.Lock()
+	m.entries[missKey(o, n)] = 1 // unix nanos in 1970
+	m.mu.Unlock()
+	if m.has(o, n) {
+		t.Fatal("expired entry must read as absent")
+	}
+	m.mu.Lock()
+	_, still := m.entries[missKey(o, n)]
+	m.mu.Unlock()
+	if still {
+		t.Fatal("expired entry should be lazily deleted on has()")
+	}
+}
+
+func TestMissCache_DisabledWhenTTLZero(t *testing.T) {
+	t.Setenv("HUB_DOWNLOAD_MISS_TTL_SEC", "0")
+	m := newMissCache()
+	m.add("0xabc", "key-1")
+	if m.has("0xabc", "key-1") {
+		t.Fatal("ttl<=0 must disable the cache (never reports present)")
+	}
+}
+
+func TestMissCache_NilSafe(t *testing.T) {
+	var m *missCache // e.g. a Server constructed without init
+	if m.has("o", "n") {
+		t.Fatal("nil cache has() must be false")
+	}
+	m.add("o", "n") // must not panic
+	m.del("o", "n") // must not panic
+}

--- a/hub/server.go
+++ b/hub/server.go
@@ -69,6 +69,9 @@ type Server struct {
 	bucketDisplayLock sync.RWMutex
 	bucketDisplay     map[string]types.BucketDisplay
 
+	// negative cache of download keys confirmed missing (download-flood guard)
+	missCache *missCache
+
 	httpServer *http.Server
 
 	// Add channels for graceful shutdown
@@ -103,6 +106,8 @@ func NewServer(rp repo.Repo) (*Server, error) {
 
 		bucketDisplay: make(map[string]types.BucketDisplay),
 		lfs:           make(map[string]*logfs.LogFS),
+
+		missCache: newMissCache(),
 
 		shutdownChan:   make(chan struct{}),
 		checkpointStop: make(chan struct{}),

--- a/hub/upload.go
+++ b/hub/upload.go
@@ -165,6 +165,9 @@ func (s *Server) logFSWrite(addr string, bucket string, key string, r io.Reader)
 		return types.MemeMeta{}, err
 	}
 
+	// Drop any stale "missing" marker so this key is immediately downloadable.
+	s.missCache.del(addr, key)
+
 	lm, err := fs.GetMeta([]byte(key))
 	if err != nil {
 		return types.MemeMeta{}, err


### PR DESCRIPTION
A client (agent) was hammering /api/download in a tight loop for keys that don't exist (proto/stake-v3-*, proto/lobby-*). Each miss runs the full fallback chain — including remote round-trips to the gateway — at ~30-50ms each. With application rate limiting removed (broken behind the reverse proxy), nothing throttled the flood, so the hub saturated and legitimate reads (listNeedle) timed out with 504.

Add a small TTL negative cache (hub/misscache.go): once a key is confirmed missing everywhere, subsequent download lookups for it short-circuit to a cheap 404 until the TTL (default 30s, HUB_DOWNLOAD_MISS_TTL_SEC) expires.

  - download(): after a local LogFS miss, consult the cache before the expensive remote fallback; on a full miss, record the key.
  - logFSWrite(): evict the key on write so a freshly stored entry is never shadowed by a stale negative.
  - Only the remote fallback is skipped — the cheap local lookup always runs first, so correctness is preserved. Bounded size (50k) with lazy expiry + reset. nil-safe; ttl<=0 disables it.

The flood hits a small repeating key set, so after the first miss per key all repeats are cheap and the hub no longer saturates.

Tests: hub/misscache_test.go (add/has/del, expiry, disable, nil-safe). go build/vet + full hub test suite green.