### PR TITLE
hub: re-add per-IP rate limiting (abuser now on a dedicated IP)

### DIFF
--- a/cmd/hub-mock/main.go
+++ b/cmd/hub-mock/main.go
@@ -1,7 +1,7 @@
 // hub-mock is a tiny standalone server that mounts ONLY the /api middlewares
-// (MaxBodySize, AuthMiddleware) plus dummy handlers, so you can exercise the
-// auth/size rejection paths with curl without running a real hub (no chain,
-// no LogFS, no SQLite).
+// (MaxBodySize, AuthMiddleware, RateLimit) plus dummy handlers, so you can
+// exercise the auth/size/rate rejection paths with curl without running a real
+// hub (no chain, no LogFS, no SQLite).
 //
 // Usage:
 //
@@ -30,6 +30,7 @@ func main() {
 	g := r.Group("/api")
 	g.Use(hub.MaxBodySize())
 	g.Use(hub.AuthMiddleware())
+	g.Use(hub.RateLimit())
 
 	// bypassed
 	g.GET("/info", func(c *gin.Context) {

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
 	golang.org/x/image v0.15.0
 	golang.org/x/sync v0.9.0
+	golang.org/x/time v0.7.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gorm.io/datatypes v1.2.5
 	gorm.io/driver/postgres v1.5.7

--- a/hub/auth.go
+++ b/hub/auth.go
@@ -6,10 +6,12 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gin-gonic/gin"
+	"golang.org/x/time/rate"
 
 	lerror "github.com/unibaseio/da-sdk-go/lib/error"
 	"github.com/unibaseio/da-sdk-go/sdk"
@@ -28,11 +30,40 @@ const (
 	// body size caps
 	defaultMaxJSONBytes      int64 = 4 << 20  // 4 MB for /upload (JSON message)
 	defaultMaxMultipartBytes int64 = 64 << 20 // 64 MB for /uploadData (file)
+
+	// rate limit defaults. Per-IP is generous on purpose: legitimate explorer
+	// traffic all arrives from the explorer's reverse-proxy IP (one IP, many
+	// users), so the cap must clear their aggregate while still throttling a
+	// single abusive host hammering hundreds of req/s from its own IP.
+	defaultIPReqPerSec    = 50.0
+	defaultIPBurst        = 100
+	defaultOwnerReqPerSec = 20.0
+	defaultOwnerBurst     = 40
 )
 
 func envInt64(key string, fallback int64) int64 {
 	if v := os.Getenv(key); v != "" {
 		n, err := strconv.ParseInt(v, 10, 64)
+		if err == nil {
+			return n
+		}
+	}
+	return fallback
+}
+
+func envFloat(key string, fallback float64) float64 {
+	if v := os.Getenv(key); v != "" {
+		f, err := strconv.ParseFloat(v, 64)
+		if err == nil {
+			return f
+		}
+	}
+	return fallback
+}
+
+func envInt(key string, fallback int) int {
+	if v := os.Getenv(key); v != "" {
+		n, err := strconv.Atoi(v)
 		if err == nil {
 			return n
 		}
@@ -252,4 +283,80 @@ func ResolveOwnerForList(c *gin.Context, owner string) (string, bool) {
 	}
 
 	return CanonOwner(owner), true
+}
+
+// ----------------------------------------------------------------------------
+// Rate limiting (per-IP + per-owner)
+// ----------------------------------------------------------------------------
+//
+// Reinstated as a per-IP guard. It works correctly when abusive hosts connect
+// from their own IP (the case we observed: a bot hammering /api/download from
+// a dedicated IP). Legitimate explorer traffic arrives from the explorer's
+// reverse-proxy IP — one IP shared by many users — so the per-IP cap is set
+// generously (see defaults above) to clear that aggregate while still cutting
+// off a single host doing hundreds of req/s.
+//
+// NOTE: behind a proxy, c.ClientIP() reflects the proxy IP unless gin is told
+// to trust it (SetTrustedProxies) and the proxy forwards X-Forwarded-For. We
+// deliberately do NOT trust-all + read XFF here, because that lets any client
+// spoof its IP and dodge the limit. So this throttles per *connecting* IP,
+// which is exactly right for direct abusers and safe (just coarse) for proxied
+// traffic. The download negative cache is the primary flood absorber; this is
+// defense-in-depth.
+
+type limiterRegistry struct {
+	mu       sync.Mutex
+	limiters map[string]*rate.Limiter
+	r        rate.Limit
+	burst    int
+}
+
+func newLimiterRegistry(rps float64, burst int) *limiterRegistry {
+	return &limiterRegistry{
+		limiters: make(map[string]*rate.Limiter),
+		r:        rate.Limit(rps),
+		burst:    burst,
+	}
+}
+
+func (lr *limiterRegistry) get(key string) *rate.Limiter {
+	lr.mu.Lock()
+	defer lr.mu.Unlock()
+	if l, ok := lr.limiters[key]; ok {
+		return l
+	}
+	l := rate.NewLimiter(lr.r, lr.burst)
+	lr.limiters[key] = l
+	return l
+}
+
+// RateLimit enforces a per-IP token bucket, plus a per-owner bucket once
+// AuthMiddleware has recovered a signer. Returns 429 on either tier.
+func RateLimit() gin.HandlerFunc {
+	ipRPS := envFloat("HUB_RATE_IP_RPS", defaultIPReqPerSec)
+	ipBurst := envInt("HUB_RATE_IP_BURST", defaultIPBurst)
+	ownerRPS := envFloat("HUB_RATE_OWNER_RPS", defaultOwnerReqPerSec)
+	ownerBurst := envInt("HUB_RATE_OWNER_BURST", defaultOwnerBurst)
+
+	ipReg := newLimiterRegistry(ipRPS, ipBurst)
+	ownerReg := newLimiterRegistry(ownerRPS, ownerBurst)
+
+	return func(c *gin.Context) {
+		ip := c.ClientIP()
+		if ip != "" && !ipReg.get(ip).Allow() {
+			logger.Warnf("rate limit hit (ip) from %s %s", ip, c.Request.URL.Path)
+			c.AbortWithStatusJSON(http.StatusTooManyRequests, lerror.ToAPIError("hub", fmt.Errorf("rate limit exceeded")))
+			return
+		}
+
+		if addr := CtxAuthAddr(c); addr != "" {
+			if !ownerReg.get(addr).Allow() {
+				logger.Warnf("rate limit hit (owner) from %s %s", addr, c.Request.URL.Path)
+				c.AbortWithStatusJSON(http.StatusTooManyRequests, lerror.ToAPIError("hub", fmt.Errorf("rate limit exceeded")))
+				return
+			}
+		}
+
+		c.Next()
+	}
 }

--- a/hub/auth_test.go
+++ b/hub/auth_test.go
@@ -325,3 +325,26 @@ func TestMaxBodySize_RejectsHugePayload(t *testing.T) {
 		t.Fatalf("expected non-200 (body too large), got 200 body=%s", w.Body.String())
 	}
 }
+
+func TestRateLimit_PerIPKicks(t *testing.T) {
+	t.Setenv("HUB_RATE_IP_RPS", "1")
+	t.Setenv("HUB_RATE_IP_BURST", "3")
+	r := gin.New()
+	g := r.Group("/api")
+	g.Use(RateLimit())
+	g.GET("/listBucket", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) })
+
+	hits429 := 0
+	for i := 0; i < 10; i++ {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/api/listBucket", nil)
+		req.RemoteAddr = "203.0.113.7:1234" // same IP each time → shared bucket
+		r.ServeHTTP(w, req)
+		if w.Code == http.StatusTooManyRequests {
+			hits429++
+		}
+	}
+	if hits429 == 0 {
+		t.Fatalf("expected at least one 429 from a single IP doing 10 rapid requests (burst=3)")
+	}
+}

--- a/hub/server.go
+++ b/hub/server.go
@@ -159,18 +159,16 @@ func (s *Server) registRoute() {
 
 	s.Router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 
-	// Public, read-only /api group: body-size cap, but NO Authorization
-	// required — these endpoints are browsable like a block explorer. Stored
-	// content is client-encrypted, so listing/downloading exposes only
-	// ciphertext plus metadata.
-	//
-	// No application-level rate limiting: the hub sits behind a reverse proxy
-	// (explorer api_hub), so every request arrives from the proxy's single IP
-	// and a per-IP limiter collapses into a global one that 429s legitimate
-	// traffic. Rate limiting, if needed, belongs at the proxy where the real
-	// client IP is visible.
+	// Public, read-only /api group: body-size cap + per-IP rate limit, but NO
+	// Authorization required — these endpoints are browsable like a block
+	// explorer. Stored content is client-encrypted, so listing/downloading
+	// exposes only ciphertext plus metadata. The per-IP limit (generous by
+	// default) throttles a single abusive host without blocking the shared
+	// explorer reverse-proxy IP; the download negative cache is the primary
+	// flood absorber.
 	pub := s.Router.Group("/api")
 	pub.Use(MaxBodySize())
+	pub.Use(RateLimit())
 
 	s.addInfo(pub)
 	s.addDownload(pub)
@@ -178,12 +176,13 @@ func (s *Server) registRoute() {
 	s.addConversation(pub)
 	s.addStat(pub)
 
-	// Mutating /api group: body-size cap → auth. AuthMiddleware requires a
-	// valid signed Authorization header, and each handler further enforces
-	// owner == signer (RequireOwnerMatch).
+	// Mutating /api group: body-size cap → auth → rate limit. AuthMiddleware
+	// requires a valid signed Authorization header, and each handler further
+	// enforces owner == signer (RequireOwnerMatch).
 	authed := s.Router.Group("/api")
 	authed.Use(MaxBodySize())
 	authed.Use(AuthMiddleware())
+	authed.Use(RateLimit())
 
 	s.addUpload(authed)
 }


### PR DESCRIPTION
Earlier removed because all traffic appeared to share the explorer's reverse-proxy IP. Confirmed since then that the flooding bot connects from its OWN dedicated IP (explorer arrives from a different IP), so a per-IP token bucket cleanly throttles the abuser without touching the explorer.

  - RateLimit() restored in auth.go: per-IP bucket + per-owner bucket (once a signer is recovered). 429 on either tier.
  - Defaults raised vs the old values (IP 50 rps / burst 100, owner 20/40) so the shared explorer-proxy IP clears its aggregate; all env-tunable (HUB_RATE_IP_RPS/_BURST, HUB_RATE_OWNER_RPS/_BURST).
  - Wired onto both the public read group and the authed write group.
  - Does NOT trust X-Forwarded-For (no SetTrustedProxies): trusting it without pinning the proxy would let clients spoof IPs and dodge the limit. Throttles per connecting IP — correct for direct abusers.
  - hub-mock + go.mod (x/time) restored; TestRateLimit_PerIPKicks added.

This is defense-in-depth; the download negative cache (a795c00) remains the primary flood absorber. For a known abuser, an iptables DROP on its IP is still the most surgical stop.