### PR TITLE
hub: serve memory stats from a background snapshot (fix 504 timeouts)

### DIFF
--- a/hub/gorm.go
+++ b/hub/gorm.go
@@ -63,6 +63,10 @@ func (s *Server) loadGORM() {
 	db.Exec("CREATE INDEX IF NOT EXISTS idx_needles_owner_name ON needles(owner, name);")
 	db.Exec("CREATE INDEX IF NOT EXISTS idx_needles_owner_bucket ON needles(owner, bucket);")
 	db.Exec("CREATE INDEX IF NOT EXISTS idx_needles_owner_bucket_name ON needles(owner, bucket, name);")
+	// expression index so the case-insensitive owner queries (LOWER(owner) used
+	// by the list/get endpoints and the memory-stats aggregation) can use an
+	// index instead of full table scans.
+	db.Exec("CREATE INDEX IF NOT EXISTS idx_needles_lower_owner ON needles(LOWER(owner));")
 
 	s.gdb = db
 
@@ -186,61 +190,42 @@ func (s *Server) listAccount(offset, limit int) ([]types.Account, error) {
 	return accounts, nil
 }
 
-// listMemoryStat returns one page of per-owner memory usage: entry count and
-// total bytes, grouped by owner (case-insensitive, so mixed-case and lowercase
-// variants of the same wallet merge). Ordered by bytes desc (biggest first).
-func (s *Server) listMemoryStat(offset, limit int) (types.MemoryStatResult, error) {
-	res := types.MemoryStatResult{Offset: offset, Length: limit, Items: []types.MemoryStat{}}
+// computeMemStats runs the heavy aggregation ONCE: a single GROUP BY over
+// needles yields the full per-owner list, from which the overview totals are
+// derived (no separate COUNT/SUM scans). This is a full-table scan and must
+// NOT be run inline per request (it 504'd behind the proxy on a large table) —
+// it's driven by the background refresh loop and the result is cached.
+//
+// Grouping/counting use LOWER(owner) so mixed-case and lowercase variants of
+// the same wallet merge (backed by idx_needles_lower_owner).
+func (s *Server) computeMemStats() (types.MemoryOverview, []types.MemoryStat, error) {
+	var ov types.MemoryOverview
 
-	// total distinct owners — for pagination
-	var total int64
-	if err := s.gdb.Model(&types.Needle{}).
-		Select("COUNT(DISTINCT LOWER(owner))").Row().Scan(&total); err != nil {
-		return res, err
+	if err := s.gdb.Model(&types.Account{}).Count(&ov.TotalAddresses).Error; err != nil {
+		return ov, nil, err
 	}
-	res.Total = total
 
-	var rows []types.MemoryStat
+	owners := []types.MemoryStat{}
 	err := s.gdb.Model(&types.Needle{}).
 		Select("LOWER(owner) as owner, count(*) as count, COALESCE(SUM(size),0) as bytes").
 		Group("LOWER(owner)").
 		Order("bytes desc").
-		Limit(limit).Offset(offset).
-		Scan(&rows).Error
+		Scan(&owners).Error
 	if err != nil {
-		return res, err
+		return ov, nil, err
 	}
-	for i := range rows {
-		rows[i].GB = float64(rows[i].Bytes) / 1e9
-	}
-	res.Items = rows
-	return res, nil
-}
 
-// memoryOverview returns the dashboard summary: total distinct addresses
-// (accounts), wallets that have at least one memory entry, total entry count,
-// and total stored bytes/GB.
-func (s *Server) memoryOverview() (types.MemoryOverview, error) {
-	var ov types.MemoryOverview
-
-	if err := s.gdb.Model(&types.Account{}).Count(&ov.TotalAddresses).Error; err != nil {
-		return ov, err
+	var totalCount, totalBytes int64
+	for i := range owners {
+		owners[i].GB = float64(owners[i].Bytes) / 1e9
+		totalCount += owners[i].Count
+		totalBytes += owners[i].Bytes
 	}
-	if err := s.gdb.Model(&types.Needle{}).
-		Select("COUNT(DISTINCT LOWER(owner))").Row().Scan(&ov.WalletsWithMemory); err != nil {
-		return ov, err
-	}
-	if err := s.gdb.Model(&types.Needle{}).Count(&ov.MemoryCount).Error; err != nil {
-		return ov, err
-	}
-	var bytes int64
-	if err := s.gdb.Model(&types.Needle{}).
-		Select("COALESCE(SUM(size),0)").Row().Scan(&bytes); err != nil {
-		return ov, err
-	}
-	ov.MemoryBytes = bytes
-	ov.MemoryGB = float64(bytes) / 1e9
-	return ov, nil
+	ov.WalletsWithMemory = int64(len(owners))
+	ov.MemoryCount = totalCount
+	ov.MemoryBytes = totalBytes
+	ov.MemoryGB = float64(totalBytes) / 1e9
+	return ov, owners, nil
 }
 
 func (s *Server) getBucket(owner, bucket string) ([]types.BucketDisplay, error) {

--- a/hub/memorystat_test.go
+++ b/hub/memorystat_test.go
@@ -2,6 +2,7 @@ package hub
 
 import (
 	"testing"
+	"time"
 
 	"github.com/unibaseio/da-sdk-go/lib/types"
 	"gorm.io/driver/sqlite"
@@ -26,7 +27,7 @@ func newStatTestServer(t *testing.T) *Server {
 	if err := db.AutoMigrate(&types.Needle{}, &types.Account{}); err != nil {
 		t.Fatalf("migrate: %v", err)
 	}
-	return &Server{gdb: db}
+	return &Server{gdb: db, memStat: &memStatCache{}}
 }
 
 func seedNeedle(t *testing.T, s *Server, owner string, size uint64) {
@@ -43,141 +44,127 @@ func seedAccount(t *testing.T, s *Server, name string) {
 	}
 }
 
-func TestMemoryOverview(t *testing.T) {
+func TestComputeMemStats_AggregatesPerOwner(t *testing.T) {
 	s := newStatTestServer(t)
-	// 5 known addresses on the hub...
-	for _, a := range []string{"0xa1", "0xa2", "0xa3", "0xa4", "0xa5"} {
-		seedAccount(t, s, a)
-	}
-	// ...but only 2 of them actually have memory entries.
-	seedNeedle(t, s, "0xA1", 100) // mixed case; merges with 0xa1 below
-	seedNeedle(t, s, "0xa1", 200)
-	seedNeedle(t, s, "0xa2", 50)
+	// owner A: 3 entries, 100+200+300 = 600 bytes (mixed + lower case → merge)
+	seedNeedle(t, s, "0xAAAa000000000000000000000000000000000001", 100)
+	seedNeedle(t, s, "0xAAAa000000000000000000000000000000000001", 200)
+	seedNeedle(t, s, "0xaaaa000000000000000000000000000000000001", 300)
+	// owner B: 1 entry, 50 bytes
+	seedNeedle(t, s, "0xBBBB000000000000000000000000000000000002", 50)
+	// 3 accounts on the hub (one has no memory)
+	seedAccount(t, s, "0xaaaa000000000000000000000000000000000001")
+	seedAccount(t, s, "0xbbbb000000000000000000000000000000000002")
+	seedAccount(t, s, "0xcccc000000000000000000000000000000000003")
 
-	ov, err := s.memoryOverview()
+	ov, owners, err := s.computeMemStats()
 	if err != nil {
-		t.Fatalf("memoryOverview: %v", err)
+		t.Fatalf("computeMemStats: %v", err)
 	}
-	if ov.TotalAddresses != 5 {
-		t.Errorf("TotalAddresses: want 5, got %d", ov.TotalAddresses)
+
+	if ov.TotalAddresses != 3 {
+		t.Errorf("TotalAddresses: want 3, got %d", ov.TotalAddresses)
 	}
 	if ov.WalletsWithMemory != 2 {
 		t.Errorf("WalletsWithMemory: want 2 (case-merged), got %d", ov.WalletsWithMemory)
 	}
-	if ov.MemoryCount != 3 {
-		t.Errorf("MemoryCount: want 3, got %d", ov.MemoryCount)
+	if ov.MemoryCount != 4 {
+		t.Errorf("MemoryCount: want 4, got %d", ov.MemoryCount)
 	}
-	if ov.MemoryBytes != 350 {
-		t.Errorf("MemoryBytes: want 350, got %d", ov.MemoryBytes)
+	if ov.MemoryBytes != 650 {
+		t.Errorf("MemoryBytes: want 650, got %d", ov.MemoryBytes)
 	}
-	if ov.MemoryGB != 350.0/1e9 {
-		t.Errorf("MemoryGB: want %v, got %v", 350.0/1e9, ov.MemoryGB)
+	if len(owners) != 2 {
+		t.Fatalf("want 2 owners, got %d", len(owners))
+	}
+	// sorted by bytes desc → A (600) first
+	if owners[0].Owner != "0xaaaa000000000000000000000000000000000001" ||
+		owners[0].Count != 3 || owners[0].Bytes != 600 {
+		t.Errorf("owner A wrong: %+v", owners[0])
+	}
+	if owners[1].Count != 1 || owners[1].Bytes != 50 {
+		t.Errorf("owner B wrong: %+v", owners[1])
 	}
 }
 
-func TestMemoryOverview_Empty(t *testing.T) {
+func TestComputeMemStats_Empty(t *testing.T) {
 	s := newStatTestServer(t)
-	ov, err := s.memoryOverview()
+	ov, owners, err := s.computeMemStats()
 	if err != nil {
-		t.Fatalf("memoryOverview: %v", err)
+		t.Fatal(err)
 	}
 	if ov.TotalAddresses != 0 || ov.WalletsWithMemory != 0 || ov.MemoryCount != 0 || ov.MemoryBytes != 0 {
 		t.Fatalf("want all-zero overview, got %+v", ov)
 	}
-}
-
-func TestListMemoryStat_AggregatesPerOwner(t *testing.T) {
-	s := newStatTestServer(t)
-	// owner A: 3 entries, 100+200+300 = 600 bytes
-	seedNeedle(t, s, "0xAAAa000000000000000000000000000000000001", 100)
-	seedNeedle(t, s, "0xAAAa000000000000000000000000000000000001", 200)
-	seedNeedle(t, s, "0xaaaa000000000000000000000000000000000001", 300) // same wallet, lowercase
-	// owner B: 1 entry, 50 bytes
-	seedNeedle(t, s, "0xBBBB000000000000000000000000000000000002", 50)
-
-	res, err := s.listMemoryStat(0, 10)
-	if err != nil {
-		t.Fatalf("listMemoryStat: %v", err)
-	}
-
-	// 2 distinct owners (case-insensitive merge of A's two cases)
-	if res.Total != 2 {
-		t.Fatalf("want total=2 distinct owners, got %d", res.Total)
-	}
-	if len(res.Items) != 2 {
-		t.Fatalf("want 2 items, got %d", len(res.Items))
-	}
-
-	// ordered by bytes desc → A (600) first
-	a := res.Items[0]
-	if a.Owner != "0xaaaa000000000000000000000000000000000001" {
-		t.Errorf("want owner A (lowercased) first, got %s", a.Owner)
-	}
-	if a.Count != 3 || a.Bytes != 600 {
-		t.Errorf("owner A: want count=3 bytes=600, got count=%d bytes=%d", a.Count, a.Bytes)
-	}
-	if a.GB != 600.0/1e9 {
-		t.Errorf("owner A: want gb=%v, got %v", 600.0/1e9, a.GB)
-	}
-
-	b := res.Items[1]
-	if b.Count != 1 || b.Bytes != 50 {
-		t.Errorf("owner B: want count=1 bytes=50, got count=%d bytes=%d", b.Count, b.Bytes)
+	if len(owners) != 0 {
+		t.Fatalf("want 0 owners, got %d", len(owners))
 	}
 }
 
-func TestListMemoryStat_Pagination(t *testing.T) {
+func TestMemStatCache_Pagination(t *testing.T) {
 	s := newStatTestServer(t)
-	// 5 owners, sizes 500,400,300,200,100 → deterministic desc order
-	owners := []struct {
-		addr string
-		size uint64
-	}{
-		{"0x0000000000000000000000000000000000000005", 500},
-		{"0x0000000000000000000000000000000000000004", 400},
-		{"0x0000000000000000000000000000000000000003", 300},
-		{"0x0000000000000000000000000000000000000002", 200},
-		{"0x0000000000000000000000000000000000000001", 100},
+	// build a snapshot of 5 owners directly (bypass DB; test the in-memory page)
+	owners := []types.MemoryStat{
+		{Owner: "0x5", Count: 5, Bytes: 500},
+		{Owner: "0x4", Count: 4, Bytes: 400},
+		{Owner: "0x3", Count: 3, Bytes: 300},
+		{Owner: "0x2", Count: 2, Bytes: 200},
+		{Owner: "0x1", Count: 1, Bytes: 100},
 	}
-	for _, o := range owners {
-		seedNeedle(t, s, o.addr, o.size)
+	s.memStat.set(&memStatSnapshot{
+		overview:   types.MemoryOverview{WalletsWithMemory: 5},
+		owners:     owners,
+		computedAt: time.Unix(1700000000, 0),
+	})
+
+	p1 := s.memoryStatPage(0, 2)
+	if p1.Total != 5 || len(p1.Items) != 2 || p1.Items[0].Bytes != 500 || p1.Items[1].Bytes != 400 {
+		t.Fatalf("page1 wrong: %+v", p1)
+	}
+	if p1.ComputedAt != 1700000000 {
+		t.Errorf("want ComputedAt set, got %d", p1.ComputedAt)
 	}
 
-	page1, err := s.listMemoryStat(0, 2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if page1.Total != 5 {
-		t.Fatalf("want total=5, got %d", page1.Total)
-	}
-	if len(page1.Items) != 2 || page1.Items[0].Bytes != 500 || page1.Items[1].Bytes != 400 {
-		t.Fatalf("page1 unexpected: %+v", page1.Items)
+	p3 := s.memoryStatPage(4, 2)
+	if len(p3.Items) != 1 || p3.Items[0].Bytes != 100 {
+		t.Fatalf("page3 wrong: %+v", p3)
 	}
 
-	page2, err := s.listMemoryStat(2, 2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(page2.Items) != 2 || page2.Items[0].Bytes != 300 || page2.Items[1].Bytes != 200 {
-		t.Fatalf("page2 unexpected: %+v", page2.Items)
-	}
-
-	page3, err := s.listMemoryStat(4, 2)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(page3.Items) != 1 || page3.Items[0].Bytes != 100 {
-		t.Fatalf("page3 unexpected: %+v", page3.Items)
+	// offset past the end → empty page, but total still correct
+	pEnd := s.memoryStatPage(10, 2)
+	if pEnd.Total != 5 || len(pEnd.Items) != 0 {
+		t.Fatalf("pastEnd wrong: %+v", pEnd)
 	}
 }
 
-func TestListMemoryStat_Empty(t *testing.T) {
-	s := newStatTestServer(t)
-	res, err := s.listMemoryStat(0, 10)
-	if err != nil {
-		t.Fatal(err)
+func TestMemStatCache_NotReady(t *testing.T) {
+	s := newStatTestServer(t) // memStat set but no snapshot computed yet
+	ov := s.memoryOverviewSnapshot()
+	if ov.ComputedAt != 0 || ov.MemoryCount != 0 {
+		t.Fatalf("want empty overview before first compute, got %+v", ov)
 	}
-	if res.Total != 0 || len(res.Items) != 0 {
-		t.Fatalf("want empty, got total=%d items=%d", res.Total, len(res.Items))
+	page := s.memoryStatPage(0, 10)
+	if page.Total != 0 || len(page.Items) != 0 || page.ComputedAt != 0 {
+		t.Fatalf("want empty page before first compute, got %+v", page)
+	}
+}
+
+func TestRefreshMemStats_PopulatesCache(t *testing.T) {
+	s := newStatTestServer(t)
+	seedNeedle(t, s, "0xAbc0000000000000000000000000000000000001", 1000)
+	seedAccount(t, s, "0xabc0000000000000000000000000000000000001")
+
+	s.refreshMemStats()
+
+	ov := s.memoryOverviewSnapshot()
+	if ov.ComputedAt == 0 {
+		t.Fatal("ComputedAt should be set after refresh")
+	}
+	if ov.WalletsWithMemory != 1 || ov.MemoryCount != 1 || ov.MemoryBytes != 1000 {
+		t.Fatalf("overview wrong after refresh: %+v", ov)
+	}
+	page := s.memoryStatPage(0, 10)
+	if page.Total != 1 || len(page.Items) != 1 || page.Items[0].Bytes != 1000 {
+		t.Fatalf("page wrong after refresh: %+v", page)
 	}
 }

--- a/hub/memstat.go
+++ b/hub/memstat.go
@@ -1,0 +1,108 @@
+package hub
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/unibaseio/da-sdk-go/lib/types"
+)
+
+// memStatRefreshInterval is how often the per-owner memory aggregates are
+// recomputed in the background.
+const memStatRefreshInterval = 2 * time.Minute
+
+// memStatSnapshot is a point-in-time result of computeMemStats, served to the
+// /api/memoryOverview and /api/memoryStat endpoints without touching the DB.
+type memStatSnapshot struct {
+	overview   types.MemoryOverview
+	owners     []types.MemoryStat // sorted by bytes desc
+	computedAt time.Time
+}
+
+type memStatCache struct {
+	mu   sync.RWMutex
+	snap *memStatSnapshot
+}
+
+func (m *memStatCache) get() *memStatSnapshot {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.snap
+}
+
+func (m *memStatCache) set(s *memStatSnapshot) {
+	m.mu.Lock()
+	m.snap = s
+	m.mu.Unlock()
+}
+
+// startMemStats launches the background recompute loop. The aggregates are
+// full-table scans — too heavy to run inline per request (they timed out
+// behind the reverse proxy) — so we compute them periodically and serve the
+// cached snapshot instantly. The first compute runs async so server startup
+// is never blocked; until it lands the endpoints return an empty (ComputedAt=0)
+// result.
+func (s *Server) startMemStats(ctx context.Context) {
+	go func() {
+		s.refreshMemStats()
+		t := time.NewTicker(memStatRefreshInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-s.shutdownChan:
+				return
+			case <-t.C:
+				s.refreshMemStats()
+			}
+		}
+	}()
+}
+
+func (s *Server) refreshMemStats() {
+	ov, owners, err := s.computeMemStats()
+	if err != nil {
+		logger.Warnf("memstat recompute failed: %v", err)
+		return
+	}
+	s.memStat.set(&memStatSnapshot{
+		overview:   ov,
+		owners:     owners,
+		computedAt: time.Now(),
+	})
+	logger.Infof("memstat refreshed: %d owners, %d entries, %d bytes",
+		ov.WalletsWithMemory, ov.MemoryCount, ov.MemoryBytes)
+}
+
+// memoryOverviewSnapshot returns the cached overview (zero value with
+// ComputedAt=0 if the first compute hasn't completed yet).
+func (s *Server) memoryOverviewSnapshot() types.MemoryOverview {
+	snap := s.memStat.get()
+	if snap == nil {
+		return types.MemoryOverview{}
+	}
+	ov := snap.overview
+	ov.ComputedAt = snap.computedAt.Unix()
+	return ov
+}
+
+// memoryStatPage paginates the cached per-owner list in memory.
+func (s *Server) memoryStatPage(offset, length int) types.MemoryStatResult {
+	res := types.MemoryStatResult{Offset: offset, Length: length, Items: []types.MemoryStat{}}
+	snap := s.memStat.get()
+	if snap == nil {
+		return res
+	}
+	res.Total = int64(len(snap.owners))
+	res.ComputedAt = snap.computedAt.Unix()
+	if offset < len(snap.owners) {
+		end := offset + length
+		if end > len(snap.owners) {
+			end = len(snap.owners)
+		}
+		res.Items = snap.owners[offset:end]
+	}
+	return res
+}

--- a/hub/server.go
+++ b/hub/server.go
@@ -72,6 +72,10 @@ type Server struct {
 	// negative cache of download keys confirmed missing (download-flood guard)
 	missCache *missCache
 
+	// cached per-owner memory stats, recomputed in the background (the live
+	// aggregation is a full-table scan that timed out behind the proxy)
+	memStat *memStatCache
+
 	httpServer *http.Server
 
 	// Add channels for graceful shutdown
@@ -108,6 +112,7 @@ func NewServer(rp repo.Repo) (*Server, error) {
 		lfs:           make(map[string]*logfs.LogFS),
 
 		missCache: newMissCache(),
+		memStat:   &memStatCache{},
 
 		shutdownChan:   make(chan struct{}),
 		checkpointStop: make(chan struct{}),
@@ -130,6 +135,8 @@ func NewServer(rp repo.Repo) (*Server, error) {
 	s.statManager = sm
 
 	go s.uploadTo()
+
+	s.startMemStats(context.Background())
 
 	s.registRoute()
 

--- a/hub/stat.go
+++ b/hub/stat.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"time"
 
-	lerror "github.com/unibaseio/da-sdk-go/lib/error"
 	"github.com/unibaseio/da-sdk-go/lib/types"
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
@@ -36,12 +35,8 @@ func (s *Server) addStat(g *gin.RouterGroup) {
 //	@Failure		599	{object}	lerror.APIError
 //	@Router			/api/memoryOverview [get]
 func (s *Server) getMemoryOverview(c *gin.Context) {
-	ov, err := s.memoryOverview()
-	if err != nil {
-		c.JSON(599, lerror.ToAPIError("hub", err))
-		return
-	}
-	c.JSON(http.StatusOK, ov)
+	// served from the background-computed snapshot (no inline DB scan)
+	c.JSON(http.StatusOK, s.memoryOverviewSnapshot())
 }
 
 // listMemoryStatByGet godoc
@@ -90,12 +85,8 @@ func (s *Server) serveMemoryStat(c *gin.Context, offset, length int) {
 	if offset < 0 {
 		offset = 0
 	}
-	res, err := s.listMemoryStat(offset, length)
-	if err != nil {
-		c.JSON(599, lerror.ToAPIError("hub", err))
-		return
-	}
-	c.JSON(http.StatusOK, res)
+	// paginated from the background-computed snapshot (no inline DB scan)
+	c.JSON(http.StatusOK, s.memoryStatPage(offset, length))
 }
 
 // @Summary Get statistics by POST

--- a/lib/types/hub.go
+++ b/lib/types/hub.go
@@ -94,10 +94,11 @@ type MemoryStat struct {
 
 // MemoryStatResult is one page of per-owner memory stats.
 type MemoryStatResult struct {
-	Total  int64        `json:"total"` // total distinct owners (for pagination)
-	Offset int          `json:"offset"`
-	Length int          `json:"length"`
-	Items  []MemoryStat `json:"items"`
+	Total      int64        `json:"total"` // total distinct owners (for pagination)
+	Offset     int          `json:"offset"`
+	Length     int          `json:"length"`
+	Items      []MemoryStat `json:"items"`
+	ComputedAt int64        `json:"computedAt"` // unix secs of the cached snapshot (0 = not ready)
 }
 
 // MemoryOverview is the dashboard summary (the four overview cards).
@@ -107,6 +108,7 @@ type MemoryOverview struct {
 	MemoryCount       int64   `json:"memoryCount"`       // total memory entries (needles)
 	MemoryBytes       int64   `json:"memoryBytes"`       // total stored bytes
 	MemoryGB          float64 `json:"memoryGB"`          // memoryBytes / 1e9
+	ComputedAt        int64   `json:"computedAt"`        // unix secs of the cached snapshot (0 = not ready)
 }
 
 type Stat struct {


### PR DESCRIPTION
/api/memoryOverview and /api/memoryStat ran a full-table GROUP BY LOWER(owner) over needles inline on every request. On the live hub that table is large enough that the scan exceeded the reverse proxy timeout — both endpoints returned 504.

Compute the aggregates in the background instead and serve cached snapshots, so the endpoints never touch the DB inline (no 504 ever):

  - computeMemStats (gorm.go): a single GROUP BY yields the full per-owner list; overview totals (walletsWithMemory/count/bytes) are derived from it — one scan instead of four.
  - memStatCache + startMemStats loop (memstat.go): recompute every 2 min (first compute async so startup isn't blocked); endpoints serve the snapshot; pagination is in-memory over the cached owner list.
  - endpoints return ComputedAt (snapshot freshness); empty/ComputedAt=0 until the first compute lands.
  - add expression index idx_needles_lower_owner ON needles(LOWER(owner)) so the background scan — and the existing LOWER(owner) list/get/download queries — can use an index instead of a full scan.

Tests (memorystat_test.go): computeMemStats aggregation + case-merge + empty, in-memory pagination, not-ready state, refresh populates cache. go build/vet + full hub suite green.