### PR TITLE
hub/seal: fix 4MB body cap + bound on-chain wait (seal hardening)

### DIFF
--- a/contract/v2/contract.go
+++ b/contract/v2/contract.go
@@ -417,34 +417,50 @@ func (c *ContractManage) GetTransactionReceipt(hash common.Hash) (*types.Receipt
 	return com.GetTransactionReceipt(c.RPC, hash)
 }
 
-// CheckTx waits for txHash to be mined and reports the result, with RPC
-// failover. It polls the shared client with the same escalating backoff as the
-// legacy com.CheckTx, but distinguishes the two error cases the legacy code
-// conflated: ethereum.NotFound (endpoint reachable, tx just not mined yet →
-// keep waiting on the SAME endpoint) versus a transport error (endpoint
-// unreachable/erroring → rotateRPC to the next one). A mined-but-reverted tx is
-// analysed for its revert reason exactly as before — that is a real result, not
-// an endpoint fault, so it never triggers failover.
+// CheckTx waits (unbounded backoff) for txHash to be mined. Kept for callers
+// with no deadline of their own (node proof/challenge loops).
 func (c *ContractManage) CheckTx(txHash common.Hash) error {
+	return c.CheckTxCtx(context.Background(), txHash)
+}
+
+// CheckTxCtx waits for txHash to be mined and reports the result, with RPC
+// failover. It polls the shared client with an escalating backoff, but
+// distinguishes the two error cases the legacy com.CheckTx conflated:
+// ethereum.NotFound (endpoint reachable, tx just not mined yet → keep waiting on
+// the SAME endpoint) versus a transport error (endpoint unreachable/erroring →
+// rotateRPC to the next one). A mined-but-reverted tx is analysed for its revert
+// reason — that is a real result, not an endpoint fault, so it never triggers
+// failover. It also honors ctx: a cancelled/expired ctx aborts the wait
+// immediately instead of sleeping through the full backoff (worst case tens of
+// minutes), so synchronous HTTP handlers (e.g. /api/seal) can bound it.
+// context.Background() reproduces the original unbounded behavior.
+func (c *ContractManage) CheckTxCtx(ctx context.Context, txHash common.Hash) error {
 	com.Logger.Debug("check tx: ", txHash.String())
 	var receipt *types.Receipt
 
 	t := 0
 	for i := 0; i < 10; i++ {
 		t = 2*t + 1
-		time.Sleep(time.Duration(t) * time.Second)
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("%s wait aborted: %w", txHash, ctx.Err())
+		case <-time.After(time.Duration(t) * time.Second):
+		}
 
-		cl, err := c.Client(context.Background())
+		cl, err := c.Client(ctx)
 		if err != nil {
 			c.rotateRPC() // can't even dial → try the next endpoint
 			continue
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		r, err := cl.TransactionReceipt(ctx, txHash)
+		rctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		r, err := cl.TransactionReceipt(rctx, txHash)
 		cancel()
 		if err == nil {
 			receipt = r
 			break
+		}
+		if ctx.Err() != nil {
+			return fmt.Errorf("%s wait aborted: %w", txHash, ctx.Err())
 		}
 		if !errors.Is(err, ethereum.NotFound) {
 			// not "not mined yet" — the endpoint is unreachable/erroring.

--- a/contract/v2/set.go
+++ b/contract/v2/set.go
@@ -177,10 +177,21 @@ func (c *ContractManage) RegisterNode(_typ uint8, val *big.Int) error {
 	return err
 }
 
+// AddPiece registers a piece on-chain (IncreaseAllowance + addPiece) under the
+// default 3-minute budget. See AddPieceCtx for a caller-supplied deadline.
 func (c *ContractManage) AddPiece(pc types.PieceCore) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	return c.AddPieceCtx(ctx, pc)
+}
+
+// AddPieceCtx is AddPiece with a caller-supplied context. ctx bounds the whole
+// flow — the contract-binding calls AND the two CheckTx receipt waits (which
+// previously escaped AddPiece's own timeout). A synchronous HTTP handler passes
+// a short ctx so a stuck tx can't hold the request open; on ctx expiry the blob
+// is already staged, so the (idempotent) seal can be retried to confirm.
+func (c *ContractManage) AddPieceCtx(ctx context.Context, pc types.PieceCore) (string, error) {
 	com.Logger.Debug("add piece: ", pc)
-	ctx, cancle := context.WithTimeout(context.TODO(), 3*time.Minute)
-	defer cancle()
 
 	ce, err := c.GetEpoch()
 	if err != nil {
@@ -202,6 +213,7 @@ func (c *ContractManage) AddPiece(pc types.PieceCore) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	au.Context = ctx // a cancelled ctx aborts the send's EstimateGas too
 
 	ti, err := c.NewToken(ctx)
 	if err != nil {
@@ -214,7 +226,7 @@ func (c *ContractManage) AddPiece(pc types.PieceCore) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	err = c.CheckTx(tx.Hash())
+	err = c.CheckTxCtx(ctx, tx.Hash())
 	if err != nil {
 		return "", err
 	}
@@ -235,11 +247,12 @@ func (c *ContractManage) AddPiece(pc types.PieceCore) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	au.Context = ctx
 	tx, err = fi.AddPiece(au, pb, pc.Price, uint64(pc.Size), pc.Expire, pc.Policy.N, pc.Policy.K, pc.Streamer)
 	if err != nil {
 		return "", err
 	}
-	err = c.CheckTx(tx.Hash())
+	err = c.CheckTxCtx(ctx, tx.Hash())
 	if err != nil {
 		return "", err
 	}

--- a/hub/auth.go
+++ b/hub/auth.go
@@ -53,14 +53,18 @@ var authBypassPaths = map[string]bool{
 // ----------------------------------------------------------------------------
 
 // MaxBodySize wraps r.Body with http.MaxBytesReader using a per-route cap.
-// /uploadData (multipart) gets the larger cap, everything else gets the JSON cap.
+// Multipart file-upload routes (/uploadData, /seal) get the larger cap;
+// everything else gets the JSON cap.
 func MaxBodySize() gin.HandlerFunc {
 	jsonCap := env.Int64("HUB_MAX_JSON_BYTES", defaultMaxJSONBytes)
 	multipartCap := env.Int64("HUB_MAX_MULTIPART_BYTES", defaultMaxMultipartBytes)
 
 	return func(c *gin.Context) {
 		var capBytes int64 = jsonCap
-		if c.Request.URL.Path == "/api/uploadData" {
+		switch c.Request.URL.Path {
+		case "/api/uploadData", "/api/seal":
+			// both stream a (potentially large) file part — must not be
+			// truncated by the small JSON cap.
 			capBytes = multipartCap
 		}
 		c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, capBytes)

--- a/hub/seal.go
+++ b/hub/seal.go
@@ -1,22 +1,31 @@
 package hub
 
 import (
+	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
 	"net/http"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	com "github.com/unibaseio/da-sdk-go/contract/common"
 	contract "github.com/unibaseio/da-sdk-go/contract/v2"
+	"github.com/unibaseio/da-sdk-go/lib/env"
 	lerror "github.com/unibaseio/da-sdk-go/lib/error"
 	"github.com/unibaseio/da-sdk-go/lib/key"
 	"github.com/unibaseio/da-sdk-go/lib/types"
 	"github.com/unibaseio/da-sdk-go/sdk"
 )
+
+// defaultSealChainTimeoutSec bounds the synchronous on-chain registration in the
+// /api/seal register=hub path. On expiry the blob is already erasure-staged; the
+// client retries seal (idempotent) to confirm the on-chain serial.
+const defaultSealChainTimeoutSec int64 = 90
 
 func (s *Server) addSeal(g *gin.RouterGroup) {
 	g.Group("/").POST("/seal", s.seal)
@@ -154,8 +163,30 @@ func (s *Server) seal(c *gin.Context) {
 		// v1: hub signs AddPiece + pays gas; client needs no chain interaction.
 		txn := ""
 		if serial == 0 {
-			txn, err = cm.AddPiece(pc)
+			// bound the on-chain wait so a stuck tx can't hold this request open
+			// for the full CheckTx backoff (tens of minutes).
+			chainCtx, cancel := context.WithTimeout(context.Background(),
+				time.Duration(env.Int64("HUB_SEAL_CHAIN_TIMEOUT_SEC", defaultSealChainTimeoutSec))*time.Second)
+			txn, err = cm.AddPieceCtx(chainCtx, pc)
+			cancel()
 			if err != nil {
+				if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+					// the blob is staged; only on-chain registration is pending.
+					// seal is idempotent (GetPieceSerial gate), so the client
+					// retries to confirm the serial — never a duplicate piece.
+					c.JSON(http.StatusAccepted, gin.H{
+						"register":     "hub",
+						"da_cid":       pc.Name,
+						"size":         pc.Size,
+						"policy":       gin.H{"n": policy.N, "k": policy.K},
+						"expire":       expire,
+						"add_piece_tx": "",
+						"piece_serial": uint64(0),
+						"pending":      true,
+						"detail":       "staged; on-chain registration pending, retry seal to confirm",
+					})
+					return
+				}
 				c.JSON(599, lerror.ToAPIError("hub", err))
 				return
 			}


### PR DESCRIPTION
Two fixes for the new /api/seal endpoint found in dev review:

1. /api/seal is a multipart file upload but MaxBodySize() only granted the 64MB multipart cap to /api/uploadData by exact path match, so seal blobs were truncated by http.MaxBytesReader at the 4MB JSON cap — unusable for any realistic segment. Route /api/seal to the multipart cap too.

2. seal's register=hub path called AddPiece -> CheckTx synchronously inside the HTTP handler. CheckTx's exponential backoff (1,3,..,1023s) could block a never-mined tx for tens of minutes. Add CheckTxCtx/AddPieceCtx that honor a context deadline (CheckTx/AddPiece keep their existing unbounded/3-min behavior for node proof loops), and have seal pass a bounded ctx (HUB_SEAL_CHAIN_TIMEOUT_SEC, default 90s). On expiry the blob is already staged, so seal returns 202 + pending=true; the client retries seal (idempotent via GetPieceSerial) to confirm the on-chain serial.

As a side effect AddPiece's own 3-min budget now actually bounds its two CheckTx waits, which previously escaped it.

Build/vet/gofmt clean; hub + contract/v2 tests pass.