### PR TITLE
hub: index (LOWER(owner), id) to kill listNeedle temp-sort

### DIFF
--- a/hub/gorm.go
+++ b/hub/gorm.go
@@ -63,6 +63,14 @@ func (s *Server) loadGORM() {
 	db.Exec("CREATE INDEX IF NOT EXISTS idx_needles_owner_name ON needles(owner, name);")
 	db.Exec("CREATE INDEX IF NOT EXISTS idx_needles_owner_bucket ON needles(owner, bucket);")
 	db.Exec("CREATE INDEX IF NOT EXISTS idx_needles_owner_bucket_name ON needles(owner, bucket, name);")
+	// listNeedle filters by LOWER(owner) and orders by id desc. Without a
+	// (LOWER(owner), id) index that query SEARCHes by owner but then builds a
+	// TEMP B-TREE to sort all matched rows by id — catastrophic for a wallet
+	// with millions of needles (loads them all to return 32). This index serves
+	// WHERE LOWER(owner)=? ORDER BY id via a reverse index walk (no temp sort).
+	// NOTE: on a large existing DB the first startup builds this once (minutes,
+	// write-locking) before serving — expected, do not restart mid-build.
+	db.Exec("CREATE INDEX IF NOT EXISTS idx_needles_lower_owner_id ON needles(LOWER(owner), id);")
 
 	s.gdb = db
 


### PR DESCRIPTION
listNeedle does `WHERE LOWER(owner)=? ORDER BY id DESC LIMIT n`. The existing indexes only cover the WHERE (e.g. idx_needles_lower_owner_size is ordered by size), so SQLite builds a TEMP B-TREE to sort all matched rows by id. For a wallet with ~22M needles that means materializing+sorting 22M rows to return 32 — it pegged the hub at ~3.5 cores under a trickle of list traffic.

Add idx_needles_lower_owner_id (LOWER(owner), id): serves WHERE LOWER(owner)=? ORDER BY id DESC via a reverse index walk, no temp sort. Query drops from seconds to milliseconds.

The hub builds this on startup with its own (working) write path — the host sqlite3 CLI hit a spurious "readonly" building it externally. On the existing ~26GB DB the first startup blocks a few minutes to build the index, then serves normally; do not restart mid-build.