### PR TITLE
hub: accept EIP-4361 / SIWE readable auth (backward compatible)

### DIFF
--- a/hub/auth.go
+++ b/hub/auth.go
@@ -133,19 +133,36 @@ func AuthMiddleware() gin.HandlerFunc {
 			return
 		}
 
-		// freshness: |now - au.Time| <= drift
+		// Verify the signature first, recovering the timestamp BOUND INTO the
+		// signature: au.Time for the legacy Hash||be64(Time) bytes, or the
+		// "Issued At" embedded in the SIWE message. Freshness is then checked
+		// against that bound timestamp, so a tampered envelope can't widen the
+		// window.
+		var signedAt int64
+		if len(au.Msg) > 0 {
+			// EIP-4361 / SIWE human-readable message (new clients)
+			signedAt, err = sdk.VerifySIWE(au)
+			if err != nil {
+				abortWithAuthError(c, fmt.Errorf("verify auth: %w", err))
+				return
+			}
+		} else {
+			// legacy: signature over Hash(label) || be64(Time)
+			signedAt = au.Time
+			if err := sdk.VerifyAuth(au); err != nil {
+				abortWithAuthError(c, fmt.Errorf("verify auth: %w", err))
+				return
+			}
+		}
+
+		// freshness: |now - signedAt| <= drift
 		now := time.Now().Unix()
-		delta := now - au.Time
+		delta := now - signedAt
 		if delta < 0 {
 			delta = -delta
 		}
 		if delta > drift {
 			abortWithAuthError(c, fmt.Errorf("auth timestamp out of window (delta=%ds, max=%ds)", delta, drift))
-			return
-		}
-
-		if err := sdk.VerifyAuth(au); err != nil {
-			abortWithAuthError(c, fmt.Errorf("verify auth: %w", err))
 			return
 		}
 

--- a/hub/siwe_test.go
+++ b/hub/siwe_test.go
@@ -1,0 +1,171 @@
+package hub
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+// siweMessage is the readable EIP-4361 / SIWE text the client personal_signs.
+// The hub never reconstructs it — it verifies the received bytes and only
+// parses the address line + "Issued At". This mirror lets the test produce a
+// valid signed envelope.
+func siweMessage(addr string, issuedAt time.Time) string {
+	return "hub.unibase.io wants you to sign in with your Ethereum account:\n" +
+		addr + "\n\n" +
+		"Sign in to Unibase Hub.\n\n" +
+		"URI: https://hub.unibase.io\n" +
+		"Version: 1\n" +
+		"Chain ID: 97\n" +
+		"Nonce: testnonce123456\n" +
+		"Issued At: " + issuedAt.UTC().Format(time.RFC3339)
+}
+
+// buildSiweHeader is the SIWE counterpart of buildHeader: personal_signs the
+// readable message and returns the Authorization envelope (with Msg set).
+func buildSiweHeader(t *testing.T, skHex string, issuedAt time.Time) string {
+	t.Helper()
+	sk, err := crypto.HexToECDSA(strings.TrimPrefix(skHex, "0x"))
+	if err != nil {
+		t.Fatalf("HexToECDSA: %v", err)
+	}
+	addr := crypto.PubkeyToAddress(sk.PublicKey)
+	msg := siweMessage(addr.Hex(), issuedAt)
+
+	// EIP-191 personal_sign digest over the exact message bytes.
+	pre := fmt.Sprintf("\x19Ethereum Signed Message:\n%d", len(msg))
+	digest := crypto.Keccak256([]byte(pre + msg))
+	sig, err := crypto.Sign(digest, sk)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+
+	payload := map[string]any{
+		"Type": "personal_sign",
+		"Addr": addr.Hex(),
+		"Time": issuedAt.Unix(),
+		"Sign": "0x" + fmt.Sprintf("%x", sig),
+		"Msg":  msg,
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	return string(b)
+}
+
+func siweUploadReq(hdr string) *http.Request {
+	req := httptest.NewRequest("POST", "/api/upload",
+		strings.NewReader(`{"owner":"`+testAddr+`","id":"x","message":"y"}`))
+	req.Header.Set("Content-Type", "application/json")
+	if hdr != "" {
+		req.Header.Set("Authorization", hdr)
+	}
+	return req
+}
+
+func TestAuthMiddleware_AcceptsSIWE(t *testing.T) {
+	r := newTestRouter()
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, siweUploadReq(buildSiweHeader(t, testSK, time.Now().UTC())))
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestAuthMiddleware_SIWE_RejectsStale(t *testing.T) {
+	r := newTestRouter()
+	// default drift is 600s; 1h old is well outside the window.
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, siweUploadReq(buildSiweHeader(t, testSK, time.Now().UTC().Add(-time.Hour))))
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "out of window") {
+		t.Errorf("want 'out of window', got %s", w.Body.String())
+	}
+}
+
+func TestAuthMiddleware_SIWE_RejectsTamperedMessage(t *testing.T) {
+	r := newTestRouter()
+	hdr := buildSiweHeader(t, testSK, time.Now().UTC())
+
+	// Tamper the signed text after signing: signature no longer recovers Addr.
+	var env map[string]any
+	if err := json.Unmarshal([]byte(hdr), &env); err != nil {
+		t.Fatal(err)
+	}
+	env["Msg"] = env["Msg"].(string) + " (tampered)"
+	tb, _ := json.Marshal(env)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, siweUploadReq(string(tb)))
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401 on tampered message, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestAuthMiddleware_AcceptsLegacyPersonalSign locks backward compatibility for
+// the format the CURRENTLY DEPLOYED extension sends: personal_sign over
+// label||be64(ts), with NO Msg field. Must keep verifying via the legacy path.
+func TestAuthMiddleware_AcceptsLegacyPersonalSign(t *testing.T) {
+	r := newTestRouter()
+	sk, err := crypto.HexToECDSA(testSK)
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := crypto.PubkeyToAddress(sk.PublicKey)
+	label := "upload"
+	ts := time.Now().Unix()
+
+	b := make([]byte, len(label)+8)
+	copy(b, label)
+	binary.BigEndian.PutUint64(b[len(label):], uint64(ts))
+	pre := fmt.Sprintf("\x19Ethereum Signed Message:\n%d", len(b))
+	sig, err := crypto.Sign(crypto.Keccak256(append([]byte(pre), b...)), sk)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	payload := map[string]any{
+		"Type": "personal_sign",
+		"Addr": addr.Hex(),
+		"Time": ts,
+		"Hash": "0x" + fmt.Sprintf("%x", []byte(label)),
+		"Sign": "0x" + fmt.Sprintf("%x", sig),
+		// no Msg → legacy path
+	}
+	jb, _ := json.Marshal(payload)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, siweUploadReq(string(jb)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("legacy personal_sign want 200, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestAuthMiddleware_SIWE_RejectsAddrSwap proves the envelope Addr can't be
+// swapped to a victim: VerifySIWE recovers the real signer from Msg and it must
+// equal Addr, so claiming a different Addr fails.
+func TestAuthMiddleware_SIWE_RejectsAddrSwap(t *testing.T) {
+	r := newTestRouter()
+	hdr := buildSiweHeader(t, testSK, time.Now().UTC())
+
+	var env map[string]any
+	_ = json.Unmarshal([]byte(hdr), &env)
+	env["Addr"] = "0x000000000000000000000000000000000000dEaD"
+	tb, _ := json.Marshal(env)
+
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, siweUploadReq(string(tb)))
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401 on Addr swap, got %d body=%s", w.Code, w.Body.String())
+	}
+}

--- a/lib/types/api.go
+++ b/lib/types/api.go
@@ -18,6 +18,11 @@ type Auth struct {
 	Time int64
 	Hash []byte
 	Sign []byte
+	// Msg, when set, carries a human-readable EIP-4361 / SIWE message that was
+	// personal_signed verbatim (instead of the legacy Hash||be64(Time) bytes).
+	// The verifier recovers the signer over Msg and reads the timestamp from it.
+	// Empty for legacy clients — kept omitempty so their envelopes are unchanged.
+	Msg string `json:",omitempty"`
 }
 
 type ModelResult struct {

--- a/sdk/common.go
+++ b/sdk/common.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -197,6 +198,7 @@ func DecodeAuth(authstr string) (types.Auth, error) {
 			Time int64
 			Hash string
 			Sign string
+			Msg  string
 		}
 		jau := JSAuth{}
 		err := json.Unmarshal([]byte(authstr), &jau)
@@ -207,6 +209,7 @@ func DecodeAuth(authstr string) (types.Auth, error) {
 		au.Type = jau.Type
 		au.Addr = jau.Addr
 		au.Time = jau.Time
+		au.Msg = jau.Msg
 		if strings.HasPrefix(jau.Hash, "0x") {
 			au.Hash, err = hex.DecodeString(jau.Hash[2:])
 			if err != nil {
@@ -263,6 +266,83 @@ func VerifyAuth(au types.Auth) error {
 	}
 
 	return nil
+}
+
+// personalSignDigest computes the EIP-191 personal_sign digest of msg:
+// keccak256("\x19Ethereum Signed Message:\n" + len(msg) + msg). Same construction
+// VerifyAuth uses for the "personal_sign" type, factored for reuse by VerifySIWE.
+func personalSignDigest(msg []byte) []byte {
+	h := sha3.NewLegacyKeccak256()
+	h.Write([]byte{0x19})
+	h.Write([]byte("Ethereum Signed Message:"))
+	h.Write([]byte{0x0A})
+	h.Write([]byte(strconv.Itoa(len(msg))))
+	h.Write(msg)
+	return h.Sum(nil)
+}
+
+var (
+	siweAddrRe   = regexp.MustCompile(`(?m)^0x[0-9a-fA-F]{40}$`)
+	siweIssuedRe = regexp.MustCompile(`(?mi)^Issued At:[ \t]*(.+?)[ \t]*$`)
+)
+
+// parseSIWE pulls the two security-relevant fields out of a SIWE / EIP-4361
+// message: the account address line (^0x…40 hex…$) and the "Issued At:" RFC3339
+// timestamp. The verifier does NOT reconstruct the message (it checks the
+// received bytes), so the rest of the text is free-form/human-readable.
+func parseSIWE(msg string) (addr string, issuedAt int64, err error) {
+	a := siweAddrRe.FindString(msg)
+	if a == "" {
+		return "", 0, fmt.Errorf("siwe: missing account address line")
+	}
+	m := siweIssuedRe.FindStringSubmatch(msg)
+	if m == nil {
+		return "", 0, fmt.Errorf("siwe: missing 'Issued At'")
+	}
+	t, perr := time.Parse(time.RFC3339, strings.TrimSpace(m[1]))
+	if perr != nil {
+		return "", 0, fmt.Errorf("siwe: bad 'Issued At' %q: %w", m[1], perr)
+	}
+	return strings.ToLower(a), t.Unix(), nil
+}
+
+// VerifySIWE verifies a human-readable EIP-4361 / SIWE auth. au.Sign must be a
+// personal_sign over the EXACT au.Msg text and recover au.Addr, and the account
+// address embedded in au.Msg must equal au.Addr. It returns the message's
+// "Issued At" as a unix timestamp so the caller can enforce its own freshness
+// window. Security model is identical to VerifyAuth (prove control of Addr +
+// a fresh in-signature timestamp); only the signed bytes are readable.
+func VerifySIWE(au types.Auth) (int64, error) {
+	if len(au.Msg) == 0 {
+		return 0, fmt.Errorf("siwe: empty message")
+	}
+	if len(au.Sign) != 65 {
+		return 0, fmt.Errorf("siwe: bad signature length %d", len(au.Sign))
+	}
+	sig := make([]byte, 65)
+	copy(sig, au.Sign)
+	if sig[64] >= 27 && sig[64] <= 34 {
+		sig[64] -= 27
+	} else if sig[64] >= 35 && sig[64] <= 38 {
+		sig[64] -= 35
+	}
+
+	rePub, err := crypto.Ecrecover(personalSignDigest([]byte(au.Msg)), sig)
+	if err != nil {
+		return 0, err
+	}
+	if !bytes.Equal(au.Addr.Bytes(), utils.ToEthAddress(rePub)) {
+		return 0, fmt.Errorf("siwe: signature does not match %s", au.Addr)
+	}
+
+	addrInMsg, issuedAt, err := parseSIWE(au.Msg)
+	if err != nil {
+		return 0, err
+	}
+	if addrInMsg != strings.ToLower(au.Addr.Hex()) {
+		return 0, fmt.Errorf("siwe: message address %s != envelope %s", addrInMsg, au.Addr)
+	}
+	return issuedAt, nil
 }
 
 // hash is random byte now


### PR DESCRIPTION
The legacy auth signs raw bytes label||be64(ts), which MetaMask renders as gibberish ("hubjB8$"). Add an optional human-readable SIWE path while keeping the legacy path byte-for-byte unchanged.

- lib/types: Auth gains an optional Msg string (omitempty) — the readable EIP-4361 message that was personal_signed verbatim. Old envelopes omit it.
- sdk: DecodeAuth parses Msg; new VerifySIWE recovers the signer over the exact Msg (EIP-191 personal_sign digest), requires the address embedded in the message to equal the envelope Addr, and returns the message's "Issued At" for the caller's freshness check. personalSignDigest factored out (shared shape with VerifyAuth's personal_sign branch).
- hub AuthMiddleware: if Msg is present → VerifySIWE; else → legacy VerifyAuth. Freshness is checked against the timestamp BOUND INTO the signature (au.Time for legacy, "Issued At" for SIWE), so a tampered envelope can't widen the window.

Security model is unchanged from legacy (prove control of Addr + a fresh in-signature timestamp); only the signed bytes become readable. Stateless, no server-side nonce store (timestamp window remains the replay guard, as before).

Tests: SIWE accept / stale / tampered-message / addr-swap, plus the currently-deployed extension's legacy personal_sign format still verifies.