### PR TITLE
hub: bound + recycle dbresolver replica pool (ConnMaxLifetime)

### DIFF
--- a/hub/gorm.go
+++ b/hub/gorm.go
@@ -87,7 +87,15 @@ func (s *Server) loadGORM() {
 		if err := db.Use(dbresolver.Register(dbresolver.Config{
 			Replicas: []gorm.Dialector{postgres.Open(readDSN)},
 			Policy:   dbresolver.RandomPolicy{},
-		})); err != nil {
+		}).
+			// Bound + recycle the replica pool (the writer/source pool already gets
+			// these via sqldb above). ConnMaxLifetime matters for Aurora read
+			// auto-scaling: the reader CLUSTER endpoint load-balances only on NEW
+			// connections, so without periodic recycling the pool stays pinned to the
+			// current reader(s) and a freshly scaled-out replica never receives traffic.
+			SetConnMaxLifetime(10 * time.Minute).
+			SetMaxIdleConns(5).
+			SetMaxOpenConns(20)); err != nil {
 			panic("failed to register read replica (HUB_DB_DSN_READ): " + err.Error())
 		}
 		logger.Info("dbresolver: reads → HUB_DB_DSN_READ (replica), writes/DDL → writer")


### PR DESCRIPTION
The reader cluster endpoint load-balances only on NEW connections, so without a ConnMaxLifetime the replica pool stays pinned to the current reader(s) and a freshly auto-scaled-out reader never receives traffic. Set lifetime + conn caps on the dbresolver replica pool (the writer/source pool already had these via sqldb). Prerequisite for enabling Aurora read auto-scaling.