### PR TITLE
build: make ServerURL overridable via SERVER_URL env

### DIFF
--- a/build/common.go
+++ b/build/common.go
@@ -3,7 +3,6 @@ package build
 import "os"
 
 const (
-	ServerURL    = "http://54.251.11.180:8080"
 	OPSepolia    = "op-sepolia"
 	OPBNBTestnet = "opbnb-testnet"
 	//BNBTestnet   = "bnb-testnet-v2"
@@ -11,6 +10,16 @@ const (
 	BNBTestnetV2  = "bnb-testnet-v2"
 	BNBTestnetDAO = "bnb-testnet-dao"
 )
+
+// ServerURL is the default gateway endpoint that hubs/clients use as their
+// remote. Override at runtime with the SERVER_URL env var (e.g. via docker
+// compose) so the address isn't baked into the binary.
+var ServerURL = func() string {
+	if v := os.Getenv("SERVER_URL"); v != "" {
+		return v
+	}
+	return "http://54.251.11.180:8080"
+}()
 
 func CheckChain() string {
 	ct := os.Getenv("CHAIN_TYPE")


### PR DESCRIPTION
The gateway endpoint used by hubs/clients was a hardcoded const (http://54.251.11.180:8080), so pointing them at a different gateway required a code change + rebuild. Turn it into a var initialized from the SERVER_URL env var, falling back to the same default, so it can be set at runtime (e.g. docker compose environment) without touching code.