### PR TITLE
hub: cache /v1 withTotal counts (TTL + singleflight + warm refresh)

### DIFF
--- a/hub/server.go
+++ b/hub/server.go
@@ -81,6 +81,9 @@ type Server struct {
 	// cached per-owner memory stats, recomputed in the background
 	memStat *memStatCache
 
+	// cached grand totals for /v1 list withTotal (COUNT over 34M+ rows)
+	totals *totalCache
+
 	// readonly = a reader replica (HUB_READONLY): shares the index DB but does not
 	// own local writes — skips upload routes, chain submitter, writer loop, DDL.
 	readonly bool
@@ -131,6 +134,7 @@ func NewServer(rp repo.Repo) (*Server, error) {
 
 		missCache: newMissCache(),
 		memStat:   &memStatCache{},
+		totals:    newTotalCache(),
 
 		readonly: os.Getenv("HUB_READONLY") != "",
 
@@ -176,6 +180,9 @@ func NewServer(rp repo.Repo) (*Server, error) {
 	if !s.readonly {
 		s.startMemStats(context.Background())
 	}
+
+	// keep the hot global totals warm (needles/buckets grand counts)
+	s.startTotalRefresh(context.Background())
 
 	s.registRoute()
 

--- a/hub/totalcache.go
+++ b/hub/totalcache.go
@@ -1,0 +1,117 @@
+package hub
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/unibaseio/da-sdk-go/lib/env"
+	"github.com/unibaseio/da-sdk-go/lib/types"
+	"golang.org/x/sync/singleflight"
+	"gorm.io/gorm"
+)
+
+// totalCache caches the expensive COUNT(*) results behind the /v1 lists'
+// withTotal option. The needles table is tens of millions of rows, so an exact
+// count costs seconds on Postgres; pagers tolerate a slightly stale total.
+//
+// TTL via HUB_TOTAL_CACHE_SEC (default 60; 0 disables caching). Lookups within
+// the TTL are served from memory; the first lookup after expiry recomputes it,
+// deduplicated by singleflight so a burst of first-page loads runs ONE count.
+// On recompute error a stale value keeps being served rather than failing the
+// list request.
+type totalCache struct {
+	mu sync.Mutex
+	m  map[string]totalEntry
+	sf singleflight.Group
+}
+
+type totalEntry struct {
+	val int64
+	at  time.Time
+}
+
+func newTotalCache() *totalCache { return &totalCache{m: make(map[string]totalEntry)} }
+
+func totalCacheTTL() time.Duration {
+	return time.Duration(env.Int64("HUB_TOTAL_CACHE_SEC", 60)) * time.Second
+}
+
+func (t *totalCache) get(key string, count func() (int64, error)) (int64, error) {
+	ttl := totalCacheTTL()
+	if ttl <= 0 {
+		return count()
+	}
+	t.mu.Lock()
+	e, ok := t.m[key]
+	t.mu.Unlock()
+	if ok && time.Since(e.at) < ttl {
+		return e.val, nil
+	}
+	v, err, _ := t.sf.Do(key, func() (interface{}, error) {
+		n, err := count()
+		if err != nil {
+			return int64(0), err
+		}
+		t.mu.Lock()
+		t.m[key] = totalEntry{val: n, at: time.Now()}
+		t.mu.Unlock()
+		return n, nil
+	})
+	if err != nil {
+		if ok { // serve stale over failing the whole list request
+			return e.val, nil
+		}
+		return 0, err
+	}
+	return v.(int64), nil
+}
+
+// cachedCount runs (or serves from cache) a COUNT over model with the given
+// filter, keyed by the caller-provided scope string.
+func (s *Server) cachedCount(key string, model interface{}, filter func(*gorm.DB) *gorm.DB) (int64, error) {
+	return s.totals.get(key, func() (int64, error) {
+		var n int64
+		err := filter(s.gdb.Model(model)).Count(&n).Error
+		return n, err
+	})
+}
+
+// startTotalRefresh keeps the hottest keys warm in the background so even the
+// first request after TTL expiry never pays the multi-second count: the global
+// needles total (explorer Memory page) and the global buckets total (Agents
+// page). Owner-/bucket-scoped totals stay on-demand (long tail, cheaper).
+func (s *Server) startTotalRefresh(ctx context.Context) {
+	ttl := totalCacheTTL()
+	if ttl <= 0 {
+		return
+	}
+	refresh := func() {
+		var n int64
+		if err := s.gdb.Model(&types.Needle{}).Count(&n).Error; err == nil {
+			s.totals.mu.Lock()
+			s.totals.m["needles||"] = totalEntry{val: n, at: time.Now()}
+			s.totals.mu.Unlock()
+		}
+		if err := s.gdb.Model(&types.Bucket{}).Count(&n).Error; err == nil {
+			s.totals.mu.Lock()
+			s.totals.m["buckets||"] = totalEntry{val: n, at: time.Now()}
+			s.totals.mu.Unlock()
+		}
+	}
+	go func() {
+		refresh() // warm immediately at startup
+		ticker := time.NewTicker(ttl)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-s.shutdownChan:
+				return
+			case <-ticker.C:
+				refresh()
+			}
+		}
+	}()
+}

--- a/hub/v1.go
+++ b/hub/v1.go
@@ -297,8 +297,8 @@ func (s *Server) v1ListBuckets(c *gin.Context) {
 
 	resp := gin.H{}
 	if v1WantTotal(c) {
-		var total int64
-		if err := filter(s.gdb.Model(&types.Bucket{})).Count(&total).Error; err != nil {
+		total, err := s.cachedCount("buckets|"+strings.ToLower(owner)+"|"+kind, &types.Bucket{}, filter)
+		if err != nil {
 			c.JSON(599, lerror.ToAPIError("hub", err))
 			return
 		}
@@ -461,8 +461,8 @@ func (s *Server) v1ListObjects(c *gin.Context) {
 
 	resp := gin.H{}
 	if v1WantTotal(c) {
-		var total int64
-		if err := filter(s.gdb.Model(&types.Needle{})).Count(&total).Error; err != nil {
+		total, err := s.cachedCount("needles|"+strings.ToLower(owner)+"|"+bucket, &types.Needle{}, filter)
+		if err != nil {
 			c.JSON(599, lerror.ToAPIError("hub", err))
 			return
 		}
@@ -531,8 +531,8 @@ func (s *Server) v1ListAllObjects(c *gin.Context) {
 
 	resp := gin.H{}
 	if v1WantTotal(c) {
-		var total int64
-		if err := filter(s.gdb.Model(&types.Needle{})).Count(&total).Error; err != nil {
+		total, err := s.cachedCount("needles|"+strings.ToLower(owner)+"|", &types.Needle{}, filter)
+		if err != nil {
 			c.JSON(599, lerror.ToAPIError("hub", err))
 			return
 		}


### PR DESCRIPTION
The needles table is 34M+ rows, so the exact COUNT behind withTotal=1 costs ~1.5s and every explorer first-page load paid it. Cache counts per filter scope with a TTL (HUB_TOTAL_CACHE_SEC, default 60s; 0 disables), dedupe concurrent recomputes via singleflight, and serve a stale value if a recompute fails. A background ticker keeps the two hot global keys (needles / buckets grand totals) permanently warm, so even post-expiry requests never block on the count.