### PR TITLE
hub(P4): shard read fallback — proxy non-home content reads to the ow…

### DIFF
--- a/hub/shard.go
+++ b/hub/shard.go
@@ -28,9 +28,17 @@ type shardRouter struct {
 	peers   []*url.URL
 	proxies []*httputil.ReverseProxy
 
-	proxied atomic.Int64 // writes forwarded to a peer
-	local   atomic.Int64 // writes served locally (home shard)
+	proxied     atomic.Int64 // writes forwarded to a peer
+	local       atomic.Int64 // writes served locally (home shard)
+	readProxied atomic.Int64 // reads forwarded to the owner's home shard
 }
+
+// shardFwdHeader marks a request already forwarded once by a shard peer. The
+// receiving hub must answer locally and never re-proxy: home resolution is
+// deterministic, so a second hop only happens under topology misconfig (e.g.
+// two hubs disagreeing on TOTAL) — without this guard that would ping-pong
+// forever. One hop max, then serve or fail locally.
+const shardFwdHeader = "X-Hub-Shard-Fwd"
 
 func newShardRouter() *shardRouter {
 	total := env.Int("HUB_SHARD_TOTAL", 1)
@@ -82,6 +90,7 @@ func (s *Server) shardStats() gin.H {
 		"total":          sr.total,
 		"local_writes":   sr.local.Load(),
 		"proxied_writes": sr.proxied.Load(),
+		"proxied_reads":  sr.readProxied.Load(),
 	}
 }
 
@@ -108,6 +117,13 @@ func (s *Server) shardWrite() gin.HandlerFunc {
 			c.Next() // unauthenticated — let the handler reject
 			return
 		}
+		// Already forwarded once by a peer: answer locally, never re-proxy
+		// (see shardFwdHeader — breaks the ping-pong on topology misconfig).
+		if c.GetHeader(shardFwdHeader) != "" {
+			sr.local.Add(1)
+			c.Next()
+			return
+		}
 		home := sr.shardOf(owner)
 		if home == sr.index || sr.proxies[home] == nil {
 			sr.local.Add(1)
@@ -116,7 +132,38 @@ func (s *Server) shardWrite() gin.HandlerFunc {
 		}
 		sr.proxied.Add(1)
 		logger.Debugf("shard: proxying %s write for owner %s to shard %d (%s)", c.Request.Method, owner, home, sr.peers[home])
+		c.Request.Header.Set(shardFwdHeader, "1")
 		sr.proxies[home].ServeHTTP(c.Writer, c.Request)
 		c.Abort()
 	}
+}
+
+// shardReadProxy forwards a READ to the owner's home shard and returns true if
+// it did (the response has been written; the caller must return). Reads are
+// normally served anywhere (L1/L2 cache, DA reconstruct) — but a STAGED
+// object's bytes exist ONLY in the home shard's local logfs (the needle index
+// is shared via PG; blobs are not, and the shared L2 is filled on read, not on
+// write). Without this, a read-after-write that lands on a non-home shard 404s
+// until the object is either read once on its home shard or committed to DA.
+// On a local miss the content handler calls this as the fallback: single hop
+// (forwarded requests are answered locally), and the home shard's own read
+// populates the shared L2, so subsequent reads hit the cache on any shard.
+func (s *Server) shardReadProxy(c *gin.Context, owner string) bool {
+	sr := s.shard
+	if sr == nil || owner == "" {
+		return false
+	}
+	if c.GetHeader(shardFwdHeader) != "" {
+		return false // one hop max — answer (or 404) locally
+	}
+	home := sr.shardOf(owner)
+	if home == sr.index || sr.proxies[home] == nil {
+		return false // we ARE home (or no proxy): nothing better than local
+	}
+	sr.readProxied.Add(1)
+	logger.Debugf("shard: proxying read for owner %s to home shard %d (%s)", owner, home, sr.peers[home])
+	c.Request.Header.Set(shardFwdHeader, "1")
+	sr.proxies[home].ServeHTTP(c.Writer, c.Request)
+	c.Abort()
+	return true
 }

--- a/hub/shard_test.go
+++ b/hub/shard_test.go
@@ -141,3 +141,154 @@ func TestShardWriteProxiesNonHome(t *testing.T) {
 		t.Fatalf("local = %d, want 1", sr.local.Load())
 	}
 }
+
+// TestShardReadProxyNonHome: a content read that misses locally is forwarded to
+// the owner's home shard; home-owner reads (and forwarded requests) stay local.
+func TestShardReadProxyNonHome(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var peerHit bool
+	var peerSawFwd bool
+	peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		peerHit = true
+		peerSawFwd = r.Header.Get(shardFwdHeader) != ""
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("blob-from-home"))
+	}))
+	defer peer.Close()
+
+	sr := testShardRouter(t, 0, 2, "http://127.0.0.1:1,"+peer.URL)
+	if sr == nil {
+		t.Fatal("expected enabled router")
+	}
+	s := &Server{shard: sr}
+
+	// route mimicking the content handler's miss path: local always misses,
+	// then falls back to the shard read proxy.
+	r := gin.New()
+	r.GET("/v1/c/:k", func(c *gin.Context) {
+		owner := c.GetHeader("X-Test-Owner")
+		if s.shardReadProxy(c, owner) {
+			return
+		}
+		c.String(http.StatusNotFound, "local-404")
+	})
+	local := httptest.NewServer(r)
+	defer local.Close()
+
+	var homeOwner, awayOwner string
+	for _, o := range []string{"0x01", "0x02", "0x03", "0x04", "0x05", "0x06", "0x07", "0x08"} {
+		switch sr.shardOf(o) {
+		case 0:
+			if homeOwner == "" {
+				homeOwner = o
+			}
+		case 1:
+			if awayOwner == "" {
+				awayOwner = o
+			}
+		}
+	}
+	if homeOwner == "" || awayOwner == "" {
+		t.Fatal("could not find owners for both shards")
+	}
+
+	get := func(owner, fwd string) *http.Response {
+		req, _ := http.NewRequest(http.MethodGet, local.URL+"/v1/c/x", nil)
+		req.Header.Set("X-Test-Owner", owner)
+		if fwd != "" {
+			req.Header.Set(shardFwdHeader, fwd)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("get: %v", err)
+		}
+		return resp
+	}
+
+	// away owner → proxied to home shard, fwd header set on the hop
+	resp := get(awayOwner, "")
+	body := make([]byte, 32)
+	n, _ := resp.Body.Read(body)
+	resp.Body.Close()
+	if !peerHit || resp.StatusCode != http.StatusOK || string(body[:n]) != "blob-from-home" {
+		t.Fatalf("away read should proxy to home (hit=%v code=%d body=%q)", peerHit, resp.StatusCode, body[:n])
+	}
+	if !peerSawFwd {
+		t.Fatal("forwarded request must carry the fwd guard header")
+	}
+	if sr.readProxied.Load() != 1 {
+		t.Fatalf("readProxied = %d, want 1", sr.readProxied.Load())
+	}
+
+	// home owner → local 404 (nothing better than local)
+	peerHit = false
+	resp = get(homeOwner, "")
+	resp.Body.Close()
+	if peerHit || resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("home read must stay local (hit=%v code=%d)", peerHit, resp.StatusCode)
+	}
+
+	// already-forwarded request → NEVER re-proxied, even for an away owner
+	peerHit = false
+	resp = get(awayOwner, "1")
+	resp.Body.Close()
+	if peerHit || resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("forwarded read must answer locally (hit=%v code=%d)", peerHit, resp.StatusCode)
+	}
+	if sr.readProxied.Load() != 1 {
+		t.Fatalf("readProxied after guard = %d, want still 1", sr.readProxied.Load())
+	}
+}
+
+// TestShardWriteGuardNoLoop: an already-forwarded WRITE is served locally even
+// when this node believes another shard is home (topology-misconfig safety).
+func TestShardWriteGuardNoLoop(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var peerHit bool
+	peer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		peerHit = true
+		w.WriteHeader(http.StatusTeapot)
+	}))
+	defer peer.Close()
+
+	sr := testShardRouter(t, 0, 2, "http://127.0.0.1:1,"+peer.URL)
+	if sr == nil {
+		t.Fatal("expected enabled router")
+	}
+	s := &Server{shard: sr}
+
+	var localHit bool
+	r := gin.New()
+	r.POST("/v1/x",
+		func(c *gin.Context) { c.Set(ctxAuthAddrKey, c.GetHeader("X-Test-Owner")) },
+		s.shardWrite(),
+		func(c *gin.Context) { localHit = true; c.String(http.StatusOK, "from-local") },
+	)
+	local := httptest.NewServer(r)
+	defer local.Close()
+
+	var awayOwner string
+	for _, o := range []string{"0x01", "0x02", "0x03", "0x04", "0x05", "0x06", "0x07", "0x08"} {
+		if sr.shardOf(o) == 1 {
+			awayOwner = o
+			break
+		}
+	}
+	if awayOwner == "" {
+		t.Fatal("no away owner found")
+	}
+
+	req, _ := http.NewRequest(http.MethodPost, local.URL+"/v1/x", nil)
+	req.Header.Set("X-Test-Owner", awayOwner)
+	req.Header.Set(shardFwdHeader, "1") // simulates the second hop
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	resp.Body.Close()
+	if peerHit || !localHit || resp.StatusCode != http.StatusOK {
+		t.Fatalf("forwarded write must be served locally (peer=%v local=%v code=%d)", peerHit, localHit, resp.StatusCode)
+	}
+}

--- a/hub/v1.go
+++ b/hub/v1.go
@@ -622,10 +622,31 @@ func (s *Server) v1GetObjectContent(c *gin.Context) {
 	// logFSRead resolves owner candidates (lowercase + legacy checksum); empty
 	// owner falls back to a needle-name lookup.
 	if _, err := s.logFSRead(owner, key, &w); err != nil {
+		// P4 shard fallback: a STAGED object's bytes live only on its owner's
+		// home shard (index rows are shared, logfs blobs are not, and L2 fills
+		// on read, not write). If we're not the home shard, forward the read
+		// there instead of 404ing the read-after-write window. The owner comes
+		// from the query when given, else from the shared needle index.
+		if s.shardReadProxy(c, s.routeOwner(owner, key)) {
+			return
+		}
 		c.JSON(http.StatusNotFound, lerror.ToAPIError("hub", err))
 		return
 	}
 	c.Data(http.StatusOK, "application/octet-stream", []byte(w.String()))
+}
+
+// routeOwner resolves the owner used for shard read-routing: the caller-supplied
+// owner when present, else the owner recorded on the needle (shared PG index, so
+// any shard can resolve it even without the blob).
+func (s *Server) routeOwner(owner, key string) string {
+	if owner != "" {
+		return owner
+	}
+	if ns, err := s.getNeedleByName(key); err == nil && len(ns) > 0 {
+		return ns[0].Owner
+	}
+	return ""
 }
 
 // GET /v1/pieces/{name}/content — download a committed DA piece by its


### PR DESCRIPTION
…ner's home shard

A STAGED object's bytes exist only on its owner's home shard (the needle index is shared via PG; logfs blobs are not, and the shared L2 fills on read, not on write). A content GET landing on a non-home shard therefore 404'd until the object was read once on its home shard or committed to DA — an observed ~50% read-after-write failure window through the ALB.

Fix: on a local miss, v1GetObjectContent resolves the owner (query param or the shared needle index) and transparently reverse-proxies the read to the home shard. One hop max: forwarded requests carry X-Hub-Shard-Fwd and are always answered locally — this also guards the existing WRITE proxy against a topology-misconfig ping-pong loop. The home shard's read populates the shared L2, so subsequent reads hit the cache on any shard. proxied_reads is exposed on /v1/cachestats.